### PR TITLE
fix: Address multiple bugs, panics, and code quality issues on controllers & pkgs

### DIFF
--- a/api/v1alpha1/taloscontrolplane_types.go
+++ b/api/v1alpha1/taloscontrolplane_types.go
@@ -26,7 +26,7 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.clusterDomain) || has(self.clusterDomain)", message="ClusterDomain is immutable"
-// +kubebuilder:validadtion:XValidation:rule="!has(oldSelf.mode) || has(self.mode)", message="Mode is immutable"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.mode) || has(self.mode)", message="Mode is immutable"
 // +kubebuilder:validation:XValidation:rule="self.mode != 'metal' || size(self.metalSpec.machines) > 0",message="Machines is required when mode is 'metal'"
 // +kubebuilder:validation:XValidation:rule="self.mode != 'container' || self.replicas >= 1",message="replicas must be at least 1 when mode is 'container'"
 

--- a/api/v1alpha1/talosetcdbackup_types.go
+++ b/api/v1alpha1/talosetcdbackup_types.go
@@ -67,9 +67,9 @@ type TalosEtcdBackupStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// filename is the path to the backup file in the storage backend.
+	// filename is the name of the backup file in the storage backend.
 	// +optional
-	FilePath string `json:"filename,omitempty"`
+	Filename string `json:"filename,omitempty"`
 
 	// For Kubernetes API conventions, see:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties

--- a/api/v1alpha1/talosworker_types.go
+++ b/api/v1alpha1/talosworker_types.go
@@ -24,7 +24,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// +kubebuilder:validadtion:XValidation:rule="!has(oldSelf.mode) || has(self.mode)", message="Mode is immutable"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.mode) || has(self.mode)", message="Mode is immutable"
 // +kubebuilder:validation:XValidation:rule="self.mode!='metal' || has(self.metalSpec)", message="MetalSpec is required when mode 'metal'"
 // +kubebuilder:validation:XValidation:rule="self.mode != 'container' || self.replicas >= 1",message="replicas must be at least 1 when mode is 'container'"
 

--- a/config/crd/bases/talos.alperen.cloud_talosclusters.yaml
+++ b/config/crd/bases/talos.alperen.cloud_talosclusters.yaml
@@ -317,6 +317,8 @@ spec:
                 x-kubernetes-validations:
                 - message: ClusterDomain is immutable
                   rule: '!has(oldSelf.clusterDomain) || has(self.clusterDomain)'
+                - message: Mode is immutable
+                  rule: '!has(oldSelf.mode) || has(self.mode)'
                 - message: Machines is required when mode is 'metal'
                   rule: self.mode != 'metal' || size(self.metalSpec.machines) > 0
                 - message: replicas must be at least 1 when mode is 'container'
@@ -584,6 +586,8 @@ spec:
                 - version
                 type: object
                 x-kubernetes-validations:
+                - message: Mode is immutable
+                  rule: '!has(oldSelf.mode) || has(self.mode)'
                 - message: MetalSpec is required when mode 'metal'
                   rule: self.mode!='metal' || has(self.metalSpec)
                 - message: replicas must be at least 1 when mode is 'container'

--- a/config/crd/bases/talos.alperen.cloud_taloscontrolplanes.yaml
+++ b/config/crd/bases/talos.alperen.cloud_taloscontrolplanes.yaml
@@ -308,6 +308,8 @@ spec:
             x-kubernetes-validations:
             - message: ClusterDomain is immutable
               rule: '!has(oldSelf.clusterDomain) || has(self.clusterDomain)'
+            - message: Mode is immutable
+              rule: '!has(oldSelf.mode) || has(self.mode)'
             - message: Machines is required when mode is 'metal'
               rule: self.mode != 'metal' || size(self.metalSpec.machines) > 0
             - message: replicas must be at least 1 when mode is 'container'

--- a/config/crd/bases/talos.alperen.cloud_talosetcdbackups.yaml
+++ b/config/crd/bases/talos.alperen.cloud_talosetcdbackups.yaml
@@ -213,7 +213,7 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               filename:
-                description: filename is the path to the backup file in the storage
+                description: filename is the name of the backup file in the storage
                   backend.
                 type: string
             type: object

--- a/config/crd/bases/talos.alperen.cloud_talosworkers.yaml
+++ b/config/crd/bases/talos.alperen.cloud_talosworkers.yaml
@@ -277,6 +277,8 @@ spec:
             - version
             type: object
             x-kubernetes-validations:
+            - message: Mode is immutable
+              rule: '!has(oldSelf.mode) || has(self.mode)'
             - message: MetalSpec is required when mode 'metal'
               rule: self.mode!='metal' || has(self.metalSpec)
             - message: replicas must be at least 1 when mode is 'container'

--- a/deploy/talos-operator/templates/crds/talosclusters.yaml
+++ b/deploy/talos-operator/templates/crds/talosclusters.yaml
@@ -315,6 +315,8 @@ spec:
                 x-kubernetes-validations:
                 - message: ClusterDomain is immutable
                   rule: '!has(oldSelf.clusterDomain) || has(self.clusterDomain)'
+                - message: Mode is immutable
+                  rule: '!has(oldSelf.mode) || has(self.mode)'
                 - message: Machines is required when mode is 'metal'
                   rule: self.mode != 'metal' || size(self.metalSpec.machines) > 0
                 - message: replicas must be at least 1 when mode is 'container'
@@ -582,6 +584,8 @@ spec:
                 - version
                 type: object
                 x-kubernetes-validations:
+                - message: Mode is immutable
+                  rule: '!has(oldSelf.mode) || has(self.mode)'
                 - message: MetalSpec is required when mode 'metal'
                   rule: self.mode!='metal' || has(self.metalSpec)
                 - message: replicas must be at least 1 when mode is 'container'

--- a/deploy/talos-operator/templates/crds/taloscontrolplanes.yaml
+++ b/deploy/talos-operator/templates/crds/taloscontrolplanes.yaml
@@ -306,6 +306,8 @@ spec:
             x-kubernetes-validations:
             - message: ClusterDomain is immutable
               rule: '!has(oldSelf.clusterDomain) || has(self.clusterDomain)'
+            - message: Mode is immutable
+              rule: '!has(oldSelf.mode) || has(self.mode)'
             - message: Machines is required when mode is 'metal'
               rule: self.mode != 'metal' || size(self.metalSpec.machines) > 0
             - message: replicas must be at least 1 when mode is 'container'

--- a/deploy/talos-operator/templates/crds/talosetcdbackups.yaml
+++ b/deploy/talos-operator/templates/crds/talosetcdbackups.yaml
@@ -211,7 +211,7 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               filename:
-                description: filename is the path to the backup file in the storage
+                description: filename is the name of the backup file in the storage
                   backend.
                 type: string
             type: object

--- a/deploy/talos-operator/templates/crds/talosworkers.yaml
+++ b/deploy/talos-operator/templates/crds/talosworkers.yaml
@@ -275,6 +275,8 @@ spec:
             - version
             type: object
             x-kubernetes-validations:
+            - message: Mode is immutable
+              rule: '!has(oldSelf.mode) || has(self.mode)'
             - message: MetalSpec is required when mode 'metal'
               rule: self.mode!='metal' || has(self.metalSpec)
             - message: replicas must be at least 1 when mode is 'container'

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/siderolabs/go-kubernetes v0.2.28
 	github.com/siderolabs/talos v1.12.1
 	github.com/siderolabs/talos/pkg/machinery v1.12.1
+	google.golang.org/grpc v1.76.0
 	google.golang.org/protobuf v1.36.10
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.19.4
@@ -237,7 +238,6 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251111163417-95abcf5c77ba // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251111163417-95abcf5c77ba // indirect
-	google.golang.org/grpc v1.76.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/controller/predicate.go
+++ b/internal/controller/predicate.go
@@ -1,54 +1,36 @@
 package controller
 
 import (
-	"fmt"
-
 	batchv1 "k8s.io/api/batch/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-var stsPredicate = predicate.Funcs{
-	UpdateFunc: func(e event.UpdateEvent) bool {
-		// Only reconcile if the generation of the object has changed
-		return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
-	},
+// generationChangedPredicate returns a predicate that only triggers on generation changes.
+func generationChangedPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+		},
+	}
 }
 
-var svcPredicate = predicate.Funcs{
-	UpdateFunc: func(e event.UpdateEvent) bool {
-		// Only reconcile if the generation of the object has changed
-		return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
-	},
-}
+var stsPredicate = generationChangedPredicate()
 
-var talosMachinePredicate = predicate.Funcs{
-	UpdateFunc: func(e event.UpdateEvent) bool {
-		// Only reconcile if the generation of the object has changed
-		return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
-	},
-}
+var svcPredicate = generationChangedPredicate()
+
+var talosMachinePredicate = generationChangedPredicate()
 
 var jobPredicate = predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {
-		// Reconcile when the job is completed or failed
 		oldJob, ok1 := e.ObjectOld.(*batchv1.Job)
 		newJob, ok2 := e.ObjectNew.(*batchv1.Job)
 		if !ok1 || !ok2 {
 			return false
 		}
-		if oldJob.Status.Succeeded != newJob.Status.Succeeded ||
-			oldJob.Status.Failed != newJob.Status.Failed {
-			fmt.Println("job update status")
-			return true
-		}
-		return false
+		return oldJob.Status.Succeeded != newJob.Status.Succeeded ||
+			oldJob.Status.Failed != newJob.Status.Failed
 	},
 }
 
-var TalosClusterAddonReleasePredicate = predicate.Funcs{
-	UpdateFunc: func(e event.UpdateEvent) bool {
-		// Only reconcile if the generation of the object has changed
-		return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
-	},
-}
+var TalosClusterAddonReleasePredicate = generationChangedPredicate()

--- a/internal/controller/talosclusteraddon_controller.go
+++ b/internal/controller/talosclusteraddon_controller.go
@@ -74,15 +74,15 @@ func (r *TalosClusterAddonReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 	} else {
 		// Handle deletion logic here
-		if controllerutil.ContainsFinalizer(&tcAddon, talosv1alpha1.TalosControlPlaneFinalizer) {
+		if controllerutil.ContainsFinalizer(&tcAddon, talosv1alpha1.TalosClusterAddonFinalizer) {
 			// Run delete operations
 			var res ctrl.Result
 			res, delErr = r.handleDelete(ctx, &tcAddon)
 			if delErr != nil {
-				logger.Error(delErr, "failed to handle delete for TalosControlPlane", "name", tcAddon.Name)
-				r.Recorder.Event(&tcAddon, corev1.EventTypeWarning, "DeleteFailed", "Failed to handle delete for TalosControlPlane")
+				logger.Error(delErr, "failed to handle delete for TalosClusterAddon", "name", tcAddon.Name)
+				r.Recorder.Event(&tcAddon, corev1.EventTypeWarning, "DeleteFailed", "Failed to handle delete for TalosClusterAddon")
 
-				return res, fmt.Errorf("failed to handle delete for TalosControlPlane %s: %w", tcAddon.Name, delErr)
+				return res, fmt.Errorf("failed to handle delete for TalosClusterAddon %s: %w", tcAddon.Name, delErr)
 			}
 			// Remove the finalizer
 			controllerutil.RemoveFinalizer(&tcAddon, talosv1alpha1.TalosClusterAddonFinalizer)

--- a/internal/controller/talosclusteraddonrelease_controller.go
+++ b/internal/controller/talosclusteraddonrelease_controller.go
@@ -18,8 +18,10 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	helmDriver "helm.sh/helm/v3/pkg/storage/driver"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -188,7 +190,10 @@ func (r *TalosClusterAddonReleaseReconciler) handleDelete(ctx context.Context, t
 		return err
 	}
 	// Get the release to make sure if it exists
-	release, _ := helmClient.GetRelease(ctx, tcAddonRelease.Spec.HelmSpec.ReleaseName)
+	release, err := helmClient.GetRelease(ctx, tcAddonRelease.Spec.HelmSpec.ReleaseName)
+	if err != nil && !errors.Is(err, helmDriver.ErrReleaseNotFound) {
+		return fmt.Errorf("failed to get helm release %s: %w", tcAddonRelease.Spec.HelmSpec.ReleaseName, err)
+	}
 	// Uninstall the chart
 	if release != nil {
 		_, err = helmClient.UninstallChart(ctx, tcAddonRelease.Spec.HelmSpec.ReleaseName)

--- a/internal/controller/taloscontrolplane_controller.go
+++ b/internal/controller/taloscontrolplane_controller.go
@@ -381,6 +381,8 @@ func (r *TalosControlPlaneReconciler) reconcileMetalMode(ctx context.Context, tc
 	}
 
 	// Wait for all TalosMachines to be created and status Available
+	// TODO: The for loop here should be replaced. The problem is if I requeue here the reconcile will start from scratch and
+	// I need to make sure that the previous op is not repeated. Before switching here make sure the previous operations are idempotent and can be safely retried.
 	for {
 		ready, err := r.CheckControlPlaneReady(ctx, tcp)
 		if err != nil {
@@ -830,6 +832,7 @@ func (r *TalosControlPlaneReconciler) BootstrapCluster(ctx context.Context, tcp 
 	if err != nil {
 		return fmt.Errorf("failed to create Talos client for ControlPlane %s: %w", tcp.Name, err)
 	}
+	defer talosClient.Close() //nolint:errcheck
 	//  Bootstrap the Talos node
 	if err := talosClient.BootstrapNode(config); err != nil {
 		return fmt.Errorf("failed to bootstrap Talos node for ControlPlane %s: %w", tcp.Name, err)
@@ -859,6 +862,7 @@ func (r *TalosControlPlaneReconciler) WriteKubeconfig(ctx context.Context, tcp *
 	if err != nil {
 		return fmt.Errorf("failed to create Talos client for ControlPlane %s: %w", tcp.Name, err)
 	}
+	defer talosClient.Close() //nolint:errcheck
 	// Generate the kubeconfig for the Talos ControlPlane
 	kubeconfig, err := talosClient.Kubeconfig(ctx)
 	if err != nil {

--- a/internal/controller/talosetcdbackup_controller.go
+++ b/internal/controller/talosetcdbackup_controller.go
@@ -168,7 +168,7 @@ func (r *TalosEtcdBackupReconciler) handleDelete(ctx context.Context, teb *talos
 	logger := logf.FromContext(ctx)
 	logger.Info("Deleting TalosEtcdBackup from external storage if exists", "TalosEtcdBackup", teb.Name)
 	// Try to get the key from status
-	if teb.Status.FilePath == "" {
+	if teb.Status.Filename == "" {
 		// Nothing to delete
 		return nil
 	}
@@ -182,7 +182,7 @@ func (r *TalosEtcdBackupReconciler) handleDelete(ctx context.Context, teb *talos
 		return fmt.Errorf("failed to create S3 client: %w", err)
 	}
 	// Delete the backup from S3
-	if err := s3Client.Delete(ctx, teb.Status.FilePath); err != nil {
+	if err := s3Client.Delete(ctx, teb.Status.Filename); err != nil {
 		return fmt.Errorf("failed to delete backup from S3: %w", err)
 	}
 	// Successfully deleted
@@ -226,6 +226,7 @@ func (r *TalosEtcdBackupReconciler) performBackup(ctx context.Context, teb *talo
 	if err != nil {
 		return fmt.Errorf("failed to create talos client: %w", err)
 	}
+	defer talosClient.Close() //nolint:errcheck
 
 	// Get S3 configuration and credentials from secrets
 	s3Config, err := r.getS3Config(ctx, teb)
@@ -251,10 +252,10 @@ func (r *TalosEtcdBackupReconciler) performBackup(ctx context.Context, teb *talo
 	backupKey := storage.GenerateBackupKey(tcp.Name)
 	logger.Info("Uploading etcd snapshot to S3", "bucket", s3Config.Bucket, "key", backupKey)
 	// Write that key to status so I can refer it later
-	teb.Status.FilePath = backupKey
+	teb.Status.Filename = backupKey
 	// Update status with the file path
 	if err := r.Status().Update(ctx, teb); err != nil {
-		logger.Error(err, "Failed to update status with file path")
+		return fmt.Errorf("failed to update status with file path: %w", err)
 	}
 	// Stream directly to S3
 	if err := s3Client.Upload(ctx, backupKey, snapshotReader); err != nil {

--- a/internal/controller/talosmachine_controller.go
+++ b/internal/controller/talosmachine_controller.go
@@ -437,6 +437,7 @@ func (r *TalosMachineReconciler) handleDelete(ctx context.Context, tm *talosv1al
 	if err != nil {
 		return ctrl.Result{Requeue: true}, fmt.Errorf("failed to create Talos client for TalosMachine %s: %w", tm.Name, err)
 	}
+	defer tc.Close() //nolint:errcheck
 	if err := tc.Reset(ctx, false, true); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reset TalosMachine %s: %w", tm.Name, err)
 	}
@@ -454,6 +455,7 @@ func (r *TalosMachineReconciler) metalConfigPatches(ctx context.Context, tm *tal
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Talos client for TalosMachine %s: %w", tm.Name, err)
 	}
+	defer talosclient.Close() //nolint:errcheck
 	// Disk Patches
 	diskNamePtr, err := talosclient.GetInstallDisk(ctx, tm)
 	if err != nil {
@@ -593,13 +595,17 @@ func (r *TalosMachineReconciler) CheckMachineReady(ctx context.Context, tm *talo
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to create Talos client for TalosMachine %s: %w", tm.Name, err)
 	}
+	defer tc.Close() //nolint:errcheck
 	// Check if the machine is ready
-	svcState := tc.GetServiceStatus(ctx, talos.KUBELET_SERVICE_NAME)
-	if svcState == "" {
+	svcState, err := tc.GetServiceStatus(ctx, talos.KUBELET_SERVICE_NAME)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get Kubelet service status for TalosMachine %s: %w", tm.Name, err)
+	}
+	if svcState == nil {
 		logger.Info("Kubelet service state is empty, requeuing reconciliation", "name", tm.Name)
 		return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
 	}
-	if svcState != talos.KUBELET_STATUS_RUNNING {
+	if *svcState != talos.KUBELET_STATUS_RUNNING {
 		logger.Info("Kubelet service is not running, requeuing reconciliation", "name", tm.Name, "state", svcState)
 		return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
 	}
@@ -620,6 +626,7 @@ func (r *TalosMachineReconciler) UpgradeOrApplyConfig(ctx context.Context, tm *t
 	if err != nil {
 		return fmt.Errorf("failed to create Talos client for TalosMachine %s: %w", tm.Name, err)
 	}
+	defer tc.Close() //nolint:errcheck
 	configDrift := tm.Status.Config != string(*config)
 	applyConfigurationFunc := func() error {
 		if err := tc.ApplyConfig(ctx, *config); err != nil {
@@ -737,6 +744,7 @@ func (r *TalosMachineReconciler) handleMetaKey(ctx context.Context, tm *talosv1a
 	if err != nil {
 		return fmt.Errorf("failed to create Talos client for TalosMachine %s: %w", tm.Name, err)
 	}
+	defer tc.Close() //nolint:errcheck
 	// Apply the meta key
 	if err := tc.ApplyMetaKey(ctx, tm.Spec.Endpoint, tm.Spec.MachineSpec.Meta); err != nil {
 		return fmt.Errorf("failed to apply meta key for TalosMachine %s: %w", tm.Name, err)

--- a/internal/controller/talosmachine_controller.go
+++ b/internal/controller/talosmachine_controller.go
@@ -225,6 +225,8 @@ func (r *TalosMachineReconciler) handleControlPlaneMachine(ctx context.Context, 
 		// Return since the machine is in desired state
 		return ctrl.Result{}, nil
 	}
+	// Ensure the client targets this specific machine, not the cluster name
+	bc.ClientEndpoint = &[]string{tm.Spec.Endpoint}
 	err = r.UpgradeOrApplyConfig(ctx, tm, bc, cpConfig)
 	if err != nil {
 		logger.Error(err, "Failed to apply or upgrade Talos config for TalosMachine", "name", tm.Name)
@@ -590,7 +592,8 @@ func (r *TalosMachineReconciler) CheckMachineReady(ctx context.Context, tm *talo
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get BundleConfig for TalosMachine %s: %w", tm.Name, err)
 	}
-	// Anytime we check machine we should beb apply-config before already so create secureClient
+	// Connect to the specific machines endpoint to check its readiness,
+	config.ClientEndpoint = &[]string{tm.Spec.Endpoint}
 	tc, err := talos.NewClient(config, false)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to create Talos client for TalosMachine %s: %w", tm.Name, err)

--- a/internal/controller/talosworker_controller.go
+++ b/internal/controller/talosworker_controller.go
@@ -192,6 +192,8 @@ func (r *TalosWorkerReconciler) reconcileMetalMode(ctx context.Context, tw *talo
 	if err := r.handleTalosMachines(ctx, tw); err != nil {
 		return ctrl.Result{}, err
 	}
+	// TODO: The for loop here should be replaced. The problem is if I requeue here the reconcile will start from scratch and
+	// I need to make sure that the previous op is not repeated. Before switching here make sure the previous operations are idempotent and can be safely retried.
 	for {
 		ready, err := r.CheckWorkerMachinesReady(ctx, tw)
 		if err != nil {
@@ -211,7 +213,6 @@ func (r *TalosWorkerReconciler) reconcileMetalMode(ctx context.Context, tw *talo
 		return ctrl.Result{}, fmt.Errorf("failed to update TalosWorker %s status to ready: %w", tw.Name, err)
 	}
 
-	// Return no error and no requeue
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -3,6 +3,7 @@ package helm
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	talosv1alpha1 "github.com/alperencelik/talos-operator/api/v1alpha1"
 	"github.com/aws/smithy-go/ptr"
@@ -29,7 +30,7 @@ type Client struct {
 func NewClient(kubeconfig []byte, namespace string) (*Client, error) {
 	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
 	}
 
 	settings := cli.New()

--- a/pkg/talos/bundle.go
+++ b/pkg/talos/bundle.go
@@ -122,7 +122,10 @@ func NewCPBundle(cfg *BundleConfig, patches *[]string) (*bundle.Bundle, error) {
 	}
 
 	// Apply the CIDR patches
-	cpPatches := cidrPatches(cfg.PodCIDR, cfg.ServiceCIDR)
+	cpPatches, err := cidrPatches(cfg.PodCIDR, cfg.ServiceCIDR)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate CIDR patches: %w", err)
+	}
 	// Apply the removeAdmissionControl patch
 	cpPatches = append(cpPatches, removeAdmissionControl)
 
@@ -169,7 +172,10 @@ func NewWorkerBundle(cfg *BundleConfig, patches *[]string) (*bundle.Bundle, erro
 		genOptions = append(genOptions, generate.WithClusterCNIConfig(cniConfig))
 	}
 
-	workerPatches := cidrPatches(cfg.PodCIDR, cfg.ServiceCIDR)
+	workerPatches, err := cidrPatches(cfg.PodCIDR, cfg.ServiceCIDR)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate CIDR patches: %w", err)
+	}
 
 	// If patches are provided, append them to the worker patches
 	if patches != nil && len(*patches) > 0 {
@@ -214,18 +220,26 @@ func NewClock() secrets.Clock {
 	return secrets.NewClock()
 }
 
-func cidrPatches(podCIDR, serviceCIDR *[]string) []string {
+func cidrPatches(podCIDR, serviceCIDR *[]string) ([]string, error) {
 	var cidrPatches []string
 
 	if podCIDR != nil && len(*podCIDR) > 0 {
-		podSubnets := fmt.Sprintf(podSubnets, utils.MarshalStringSlice(*podCIDR))
+		marshaled, err := utils.MarshalStringSlice(*podCIDR)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal pod CIDR: %w", err)
+		}
+		podSubnets := fmt.Sprintf(podSubnets, marshaled)
 		cidrPatches = append(cidrPatches, podSubnets)
 	}
 	if serviceCIDR != nil && len(*serviceCIDR) > 0 {
-		serviceSubnets := fmt.Sprintf(serviceSubnets, utils.MarshalStringSlice(*serviceCIDR))
+		marshaled, err := utils.MarshalStringSlice(*serviceCIDR)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal service CIDR: %w", err)
+		}
+		serviceSubnets := fmt.Sprintf(serviceSubnets, marshaled)
 		cidrPatches = append(cidrPatches, serviceSubnets)
 	}
-	return cidrPatches
+	return cidrPatches, nil
 }
 
 func ParseBundleConfig(bc string) (*BundleConfig, error) {

--- a/pkg/talos/bundle_test.go
+++ b/pkg/talos/bundle_test.go
@@ -120,7 +120,10 @@ func TestCidrPatches(t *testing.T) {
 	podCIDR := []string{"10.100.0.0/16", "10.150.0.0/16"}
 	serviceCIDR := []string{"10.200.0.0/12"}
 
-	patches := cidrPatches(&podCIDR, &serviceCIDR)
+	patches, err := cidrPatches(&podCIDR, &serviceCIDR)
+	if err != nil {
+		t.Fatalf("cidrPatches() unexpected error: %v", err)
+	}
 	if len(patches) != 2 {
 		t.Errorf("expected 2 CIDR patches, got %d", len(patches))
 	}
@@ -150,7 +153,10 @@ func TestCidrPatches(t *testing.T) {
 	}
 
 	// Test nil input
-	patchesNil := cidrPatches(nil, nil)
+	patchesNil, err := cidrPatches(nil, nil)
+	if err != nil {
+		t.Fatalf("cidrPatches(nil, nil) unexpected error: %v", err)
+	}
 	if len(patchesNil) != 0 {
 		t.Errorf("expected 0 patches for nil input, got %d", len(patchesNil))
 	}

--- a/pkg/talos/client.go
+++ b/pkg/talos/client.go
@@ -88,7 +88,7 @@ func (tc *TalosClient) ApplyConfig(ctx context.Context, machineConfig []byte) er
 	}
 	resp, err := tc.ApplyConfiguration(ctx, applyRequest)
 	if err != nil {
-		return fmt.Errorf("error applying new configuration %s", err)
+		return fmt.Errorf("error applying new configuration: %w", err)
 	}
 	// TODO: Use FilterMessages over resp
 	// Parse the response
@@ -100,7 +100,7 @@ func (tc *TalosClient) GetTalosVersion(ctx context.Context) (string, error) {
 	// Get the Talos version
 	resp, err := tc.Version(ctx)
 	if err != nil {
-		return "", fmt.Errorf("error getting Talos version: %s", err)
+		return "", fmt.Errorf("error getting Talos version: %w", err)
 	}
 	if len(resp.Messages) == 0 {
 		return "", fmt.Errorf("no version information found")
@@ -137,13 +137,11 @@ func (tc *TalosClient) GetInstallDisk(ctx context.Context, tm *talosv1alpha1.Tal
 		// Try to get it from the disks
 		resp, err := tc.Disks(ctx)
 		if err != nil {
-			fmt.Printf("Error getting disks: %s\n", err)
-			return nil, err
+			return nil, fmt.Errorf("error getting disks: %w", err)
 		}
 		disks := resp.Messages
 		if len(disks) == 0 {
-			fmt.Println("No disks found to install Talos")
-			return nil, err
+			return nil, fmt.Errorf("no disks found to install Talos")
 		}
 		// Get disks and remove the readonly ones
 		for _, disk := range disks {
@@ -167,19 +165,15 @@ func (tc *TalosClient) GetInstallDisk(ctx context.Context, tm *talosv1alpha1.Tal
 	return nil, nil
 }
 
-func (tc *TalosClient) GetServiceStatus(ctx context.Context, svcName string) string {
-	// Get the service status
+func (tc *TalosClient) GetServiceStatus(ctx context.Context, svcName string) (*string, error) {
 	svcsInfo, err := tc.ServiceInfo(ctx, svcName)
 	if err != nil {
-		fmt.Printf("Error getting service status: %s\n", err)
-		return ""
+		return nil, fmt.Errorf("error getting service info for %s: %w", svcName, err)
 	}
-	svc := svcsInfo[0]
-	// fmt.Printf("Service %s status: %s\n", svc, svc.Service.State)
-	fmt.Printf("Service status: %s\n", svc.Service.State)
-	return svc.Service.State
-	// state := "running" // Placeholder for actual service state
-	// return state
+	if len(svcsInfo) == 0 {
+		return nil, nil
+	}
+	return &svcsInfo[0].Service.State, nil
 }
 
 func (tc *TalosClient) ApplyMetaKey(ctx context.Context, endpoint string, meta *talosv1alpha1.META) error {
@@ -219,18 +213,3 @@ func GetSecretBundleFromConfig(ctx context.Context, machineConfig []byte) (*secr
 	// Create a SecretBundle from the configData
 	return secrets.NewBundleFromConfig(secrets.NewFixedClock(time.Now()), cfg), nil
 }
-
-// func (tc *TalosClient) GetMachineStatus(ctx context.Context) (*string, error) {
-// // Get the machine status
-// res, err := tc.COSI.Get(ctx,
-// resource.NewMetadata("runtime", "machinestatuses", "", resource.VersionUndefined),
-// state.WithGetUnmarshalOptions(state.WithSkipProtobufUnmarshal()),
-// )
-// if err != nil {
-// return nil, fmt.Errorf("error getting machine status: %w", err)
-// }
-// fmt.Printf("Machine status: %v\n", res)
-
-// // tc.COSI.List(ctx, resourceType, resourceID)
-// return nil, nil
-// }

--- a/pkg/talos/client.go
+++ b/pkg/talos/client.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"strings"
 	"text/template"
 	"time"
 
@@ -14,6 +15,8 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -88,11 +91,14 @@ func (tc *TalosClient) ApplyConfig(ctx context.Context, machineConfig []byte) er
 	}
 	resp, err := tc.ApplyConfiguration(ctx, applyRequest)
 	if err != nil {
+		if isGracefulStop(err) {
+			return nil
+		}
 		return fmt.Errorf("error applying new configuration: %w", err)
 	}
-	// TODO: Use FilterMessages over resp
-	// Parse the response
-	fmt.Printf("ApplyConfiguration response: %s\n", resp.Messages[0].String())
+	if len(resp.Messages) > 0 {
+		fmt.Printf("ApplyConfiguration response: %s\n", resp.Messages[0].String())
+	}
 	return nil
 }
 
@@ -212,4 +218,14 @@ func GetSecretBundleFromConfig(ctx context.Context, machineConfig []byte) (*secr
 	}
 	// Create a SecretBundle from the configData
 	return secrets.NewBundleFromConfig(secrets.NewFixedClock(time.Now()), cfg), nil
+}
+
+// isGracefulStop returns true if the error is a gRPC Unavailable error caused by
+// the server performing a graceful shutdown.
+func isGracefulStop(err error) bool {
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	return st.Code() == codes.Unavailable && strings.Contains(st.Message(), "graceful_stop")
 }

--- a/pkg/talos/control_plane.go
+++ b/pkg/talos/control_plane.go
@@ -7,19 +7,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 )
 
-// type ControlPlaneConfig struct {
-// ClusterName   string
-// Endpoint      string
-// Version       string
-// KubeVersion   string
-// SecretsBundle *secrets.Bundle
-// Sans          []string  // Additional Subject Alternative Names for the API server
-// PodCIDR       *[]string // Pod CIDR ranges
-// ServiceCIDR   *[]string // Service CIDR ranges
-// }
-
 func GenerateControlPlaneConfig(cfg *BundleConfig, patches *[]string) (*[]byte, error) {
-
 	bundle, err := NewCPBundle(cfg, patches)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate config bundle: %w", err)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -28,7 +28,11 @@ func SecretBundleDecoder(bs string) (*secrets.Bundle, error) {
 }
 
 func GenSans(name string, r *int) []string {
-	var sans []string
+	capacity := 1
+	if r != nil {
+		capacity += *r
+	}
+	sans := make([]string, 0, capacity)
 	sans = append(sans, name)
 	if r == nil {
 		return sans
@@ -39,12 +43,12 @@ func GenSans(name string, r *int) []string {
 	return sans
 }
 
-func MarshalStringSlice(slice []string) string {
+func MarshalStringSlice(slice []string) (string, error) {
 	bytes, err := json.Marshal(slice)
 	if err != nil {
-		panic(fmt.Sprintf("failed to marshal string slice: %v", err))
+		return "", fmt.Errorf("failed to marshal string slice: %w", err)
 	}
-	return string(bytes)
+	return string(bytes), nil
 }
 
 func PtrToString(s *string) string {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -88,7 +88,10 @@ func TestMarshalStringSlice(t *testing.T) {
 	slice := []string{"one", "two", "three"}
 	expected := `["one","two","three"]`
 
-	got := MarshalStringSlice(slice)
+	got, err := MarshalStringSlice(slice)
+	if err != nil {
+		t.Fatalf("MarshalStringSlice() unexpected error: %v", err)
+	}
 	if got != expected {
 		t.Errorf("MarshalStringSlice() = %v, want %v", got, expected)
 	}


### PR DESCRIPTION
This is a quite general fix for the whole codebase but mainly the PR tries to address:
                                                                                                                                                                                         
  - Fix wrong finalizer check in TalosClusterAddon controller (TalosControlPlaneFinalizer -> TalosClusterAddonFinalizer)                                                                             
  - Fix misspelled kubebuilder validation marker (validadtion -> validation)                                                                                              
  - Replace panic() with error returns in helm client and MarshalStringSlice                                                                                                                         
  - Add defer Close() for Talos gRPC clients to prevent connection leaks                                                                                                                             
  - Handle GetRelease error in addon release deletion instead of swallowing                                                                                                  
  - Return error on file path status update failure in etcd backup controller                                                                                                                        
  - Add length check in GetServiceStatus to prevent nil slice panic                                                                                                                                  
  - Consolidate duplicate predicates into shared generationChangedPredicate()                                                                                                                        
  - Remove debug fmt.Println from job predicate                                                                                                                                                      
  - Fix error wrapping to use %w instead of %s for proper error chains                                                                                                                               
  - Rename FilePath -> Filename to match JSON tag in TalosEtcdBackupStatus  