### PR TITLE
feat: Adding a field to prevent machines from being reset when a TalosMachine resource is being deleted.

### DIFF
--- a/api/v1alpha1/taloscontrolplane_types.go
+++ b/api/v1alpha1/taloscontrolplane_types.go
@@ -98,9 +98,10 @@ type TalosControlPlaneSpec struct {
 	// +kubebuilder:validation:Optional
 	CNI *CNIConfig `json:"cni,omitempty"`
 
-	// resetOnDelete indicates whether deleting this Kubernetes resource also resets the machines
-	// +kubebuilder:validation:Required
-	ResetOnDelete bool `json:"resetOnDelete"`
+	// preserveMachinesOnDeletion indicates whether control plane machines should be preserved (not reset) when deleting this Kubernetes resource
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	PreserveMachinesOnDeletion bool `json:"preserveMachinesOnDeletion"`
 }
 
 // CNIConfig represents the CNI configuration options.

--- a/api/v1alpha1/taloscontrolplane_types.go
+++ b/api/v1alpha1/taloscontrolplane_types.go
@@ -97,6 +97,10 @@ type TalosControlPlaneSpec struct {
 	// cni is the CNI configuration for the cluster.
 	// +kubebuilder:validation:Optional
 	CNI *CNIConfig `json:"cni,omitempty"`
+
+	// resetOnDelete indicates whether deleting this Kubernetes resource also resets the machines
+	// +kubebuilder:validation:Required
+	ResetOnDelete bool `json:"resetOnDelete"`
 }
 
 // CNIConfig represents the CNI configuration options.

--- a/api/v1alpha1/taloscontrolplane_types.go
+++ b/api/v1alpha1/taloscontrolplane_types.go
@@ -98,10 +98,11 @@ type TalosControlPlaneSpec struct {
 	// +kubebuilder:validation:Optional
 	CNI *CNIConfig `json:"cni,omitempty"`
 
-	// preserveMachinesOnDeletion indicates whether control plane machines should be preserved (not reset) when deleting this Kubernetes resource
+	// deletionPolicy specifies the deletion policy for control plane machines when deleting this Kubernetes resource (reset or preserve).
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=false
-	PreserveMachinesOnDeletion bool `json:"preserveMachinesOnDeletion"`
+	// +kubebuilder:validation:Enum=reset;preserve
+	// +kubebuilder:default=reset
+	DeletionPolicy string `json:"deletionPolicy"`
 }
 
 // CNIConfig represents the CNI configuration options.

--- a/api/v1alpha1/talosmachine_types.go
+++ b/api/v1alpha1/talosmachine_types.go
@@ -50,6 +50,10 @@ type TalosMachineSpec struct {
 	// configRef is a reference to a ConfigMap containing the Talos cluster configuration.
 	// +kubebuilder:validation:Optional
 	ConfigRef *corev1.ConfigMapKeySelector `json:"configRef,omitempty"`
+
+	// resetOnDelete indicates whether deleting this Kubernetes resource also resets the machine
+	// +kubebuilder:validation:Required
+	ResetOnDelete bool `json:"resetOnDelete"`
 }
 
 type MachineSpec struct {

--- a/api/v1alpha1/talosmachine_types.go
+++ b/api/v1alpha1/talosmachine_types.go
@@ -51,10 +51,11 @@ type TalosMachineSpec struct {
 	// +kubebuilder:validation:Optional
 	ConfigRef *corev1.ConfigMapKeySelector `json:"configRef,omitempty"`
 
-	// preserveMachineOnDeletion indicates whether the machine should be preserved (not reset) when deleting this Kubernetes resource
+	// deletionPolicy specifies the deletion policy for the machine when deleting this Kubernetes resource (reset or preserve).
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=false
-	PreserveMachineOnDeletion bool `json:"preserveMachineOnDeletion"`
+	// +kubebuilder:validation:Enum=reset;preserve
+	// +kubebuilder:default=reset
+	DeletionPolicy string `json:"deletionPolicy"`
 }
 
 type MachineSpec struct {

--- a/api/v1alpha1/talosmachine_types.go
+++ b/api/v1alpha1/talosmachine_types.go
@@ -51,9 +51,10 @@ type TalosMachineSpec struct {
 	// +kubebuilder:validation:Optional
 	ConfigRef *corev1.ConfigMapKeySelector `json:"configRef,omitempty"`
 
-	// resetOnDelete indicates whether deleting this Kubernetes resource also resets the machine
-	// +kubebuilder:validation:Required
-	ResetOnDelete bool `json:"resetOnDelete"`
+	// preserveMachineOnDeletion indicates whether the machine should be preserved (not reset) when deleting this Kubernetes resource
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	PreserveMachineOnDeletion bool `json:"preserveMachineOnDeletion"`
 }
 
 type MachineSpec struct {

--- a/api/v1alpha1/talosworker_types.go
+++ b/api/v1alpha1/talosworker_types.go
@@ -73,10 +73,11 @@ type TalosWorkerSpec struct {
 	// +kubebuilder:validation:Optional
 	ConfigRef *corev1.ConfigMapKeySelector `json:"configRef,omitempty"`
 
-	// preserveMachinesOnDeletion indicates whether worker machines should be preserved (not reset) when deleting this Kubernetes resource
+	// deletionPolicy specifies the deletion policy for worker machines when deleting this Kubernetes resource (reset or preserve).
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=false
-	PreserveMachinesOnDeletion bool `json:"preserveMachinesOnDeletion"`
+	// +kubebuilder:validation:Enum=reset;preserve
+	// +kubebuilder:default=reset
+	DeletionPolicy string `json:"deletionPolicy"`
 }
 
 // TalosWorkerStatus defines the observed state of TalosWorker.

--- a/api/v1alpha1/talosworker_types.go
+++ b/api/v1alpha1/talosworker_types.go
@@ -73,9 +73,10 @@ type TalosWorkerSpec struct {
 	// +kubebuilder:validation:Optional
 	ConfigRef *corev1.ConfigMapKeySelector `json:"configRef,omitempty"`
 
-	// resetOnDelete indicates whether deleting this Kubernetes resource also resets the machines
-	// +kubebuilder:validation:Required
-	ResetOnDelete bool `json:"resetOnDelete"`
+	// preserveMachinesOnDeletion indicates whether worker machines should be preserved (not reset) when deleting this Kubernetes resource
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	PreserveMachinesOnDeletion bool `json:"preserveMachinesOnDeletion"`
 }
 
 // TalosWorkerStatus defines the observed state of TalosWorker.

--- a/api/v1alpha1/talosworker_types.go
+++ b/api/v1alpha1/talosworker_types.go
@@ -72,6 +72,10 @@ type TalosWorkerSpec struct {
 	// configRef is a reference to a ConfigMap containing the Talos cluster configuration.
 	// +kubebuilder:validation:Optional
 	ConfigRef *corev1.ConfigMapKeySelector `json:"configRef,omitempty"`
+
+	// resetOnDelete indicates whether deleting this Kubernetes resource also resets the machines
+	// +kubebuilder:validation:Required
+	ResetOnDelete bool `json:"resetOnDelete"`
 }
 
 // TalosWorkerStatus defines the observed state of TalosWorker.

--- a/config/crd/bases/talos.alperen.cloud_talosclusters.yaml
+++ b/config/crd/bases/talos.alperen.cloud_talosclusters.yaml
@@ -99,6 +99,15 @@ spec:
                     - key
                     type: object
                     x-kubernetes-map-type: atomic
+                  deletionPolicy:
+                    default: reset
+                    description: deletionPolicy specifies the deletion policy for
+                      control plane machines when deleting this Kubernetes resource
+                      (reset or preserve).
+                    enum:
+                    - reset
+                    - preserve
+                    type: string
                   endpoint:
                     description: endpoint is the endpoint for the Kubernetes API Server.
                     pattern: ^https?://[a-zA-Z0-9.-]+(:\d+)?$
@@ -287,12 +296,6 @@ spec:
                     items:
                       type: string
                     type: array
-                  preserveMachinesOnDeletion:
-                    default: false
-                    description: preserveMachinesOnDeletion indicates whether control
-                      plane machines should be preserved (not reset) when deleting
-                      this Kubernetes resource
-                    type: boolean
                   replicas:
                     description: replicas is the number of control-plane machines
                       to maintain. Only applies when mode is 'container'.
@@ -388,6 +391,15 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
+                  deletionPolicy:
+                    default: reset
+                    description: deletionPolicy specifies the deletion policy for
+                      worker machines when deleting this Kubernetes resource (reset
+                      or preserve).
+                    enum:
+                    - reset
+                    - preserve
+                    type: string
                   kubeVersion:
                     default: v1.35.0
                     description: kubeVersion is the version of Kubernetes to use for
@@ -566,12 +578,6 @@ spec:
                     - metal
                     - cloud
                     type: string
-                  preserveMachinesOnDeletion:
-                    default: false
-                    description: preserveMachinesOnDeletion indicates whether worker
-                      machines should be preserved (not reset) when deleting this
-                      Kubernetes resource
-                    type: boolean
                   replicas:
                     default: 1
                     description: replicas is the number of worker machines to maintain.

--- a/config/crd/bases/talos.alperen.cloud_talosclusters.yaml
+++ b/config/crd/bases/talos.alperen.cloud_talosclusters.yaml
@@ -287,15 +287,17 @@ spec:
                     items:
                       type: string
                     type: array
+                  preserveMachinesOnDeletion:
+                    default: false
+                    description: preserveMachinesOnDeletion indicates whether control
+                      plane machines should be preserved (not reset) when deleting
+                      this Kubernetes resource
+                    type: boolean
                   replicas:
                     description: replicas is the number of control-plane machines
                       to maintain. Only applies when mode is 'container'.
                     format: int32
                     type: integer
-                  resetOnDelete:
-                    description: resetOnDelete indicates whether deleting this Kubernetes
-                      resource also resets the machines
-                    type: boolean
                   serviceCIDR:
                     description: serviceCIDR is the list of CIDR ranges for service
                       IPs in the cluster.
@@ -316,7 +318,6 @@ spec:
                 required:
                 - kubeVersion
                 - mode
-                - resetOnDelete
                 - version
                 type: object
                 x-kubernetes-validations:
@@ -565,16 +566,18 @@ spec:
                     - metal
                     - cloud
                     type: string
+                  preserveMachinesOnDeletion:
+                    default: false
+                    description: preserveMachinesOnDeletion indicates whether worker
+                      machines should be preserved (not reset) when deleting this
+                      Kubernetes resource
+                    type: boolean
                   replicas:
                     default: 1
                     description: replicas is the number of worker machines to maintain.
                       Only applies when mode is 'container'.
                     format: int32
                     type: integer
-                  resetOnDelete:
-                    description: resetOnDelete indicates whether deleting this Kubernetes
-                      resource also resets the machines
-                    type: boolean
                   storageClassName:
                     description: storageClassName is the name of the storage class
                       to use for persistent volumes.
@@ -592,7 +595,6 @@ spec:
                 required:
                 - kubeVersion
                 - mode
-                - resetOnDelete
                 - version
                 type: object
                 x-kubernetes-validations:

--- a/config/crd/bases/talos.alperen.cloud_talosclusters.yaml
+++ b/config/crd/bases/talos.alperen.cloud_talosclusters.yaml
@@ -292,6 +292,10 @@ spec:
                       to maintain. Only applies when mode is 'container'.
                     format: int32
                     type: integer
+                  resetOnDelete:
+                    description: resetOnDelete indicates whether deleting this Kubernetes
+                      resource also resets the machines
+                    type: boolean
                   serviceCIDR:
                     description: serviceCIDR is the list of CIDR ranges for service
                       IPs in the cluster.
@@ -312,6 +316,7 @@ spec:
                 required:
                 - kubeVersion
                 - mode
+                - resetOnDelete
                 - version
                 type: object
                 x-kubernetes-validations:
@@ -566,6 +571,10 @@ spec:
                       Only applies when mode is 'container'.
                     format: int32
                     type: integer
+                  resetOnDelete:
+                    description: resetOnDelete indicates whether deleting this Kubernetes
+                      resource also resets the machines
+                    type: boolean
                   storageClassName:
                     description: storageClassName is the name of the storage class
                       to use for persistent volumes.
@@ -583,6 +592,7 @@ spec:
                 required:
                 - kubeVersion
                 - mode
+                - resetOnDelete
                 - version
                 type: object
                 x-kubernetes-validations:

--- a/config/crd/bases/talos.alperen.cloud_taloscontrolplanes.yaml
+++ b/config/crd/bases/talos.alperen.cloud_taloscontrolplanes.yaml
@@ -95,6 +95,15 @@ spec:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
+              deletionPolicy:
+                default: reset
+                description: deletionPolicy specifies the deletion policy for control
+                  plane machines when deleting this Kubernetes resource (reset or
+                  preserve).
+                enum:
+                - reset
+                - preserve
+                type: string
               endpoint:
                 description: endpoint is the endpoint for the Kubernetes API Server.
                 pattern: ^https?://[a-zA-Z0-9.-]+(:\d+)?$
@@ -278,12 +287,6 @@ spec:
                 items:
                   type: string
                 type: array
-              preserveMachinesOnDeletion:
-                default: false
-                description: preserveMachinesOnDeletion indicates whether control
-                  plane machines should be preserved (not reset) when deleting this
-                  Kubernetes resource
-                type: boolean
               replicas:
                 description: replicas is the number of control-plane machines to maintain.
                   Only applies when mode is 'container'.

--- a/config/crd/bases/talos.alperen.cloud_taloscontrolplanes.yaml
+++ b/config/crd/bases/talos.alperen.cloud_taloscontrolplanes.yaml
@@ -283,6 +283,10 @@ spec:
                   Only applies when mode is 'container'.
                 format: int32
                 type: integer
+              resetOnDelete:
+                description: resetOnDelete indicates whether deleting this Kubernetes
+                  resource also resets the machines
+                type: boolean
               serviceCIDR:
                 description: serviceCIDR is the list of CIDR ranges for service IPs
                   in the cluster.
@@ -303,6 +307,7 @@ spec:
             required:
             - kubeVersion
             - mode
+            - resetOnDelete
             - version
             type: object
             x-kubernetes-validations:

--- a/config/crd/bases/talos.alperen.cloud_taloscontrolplanes.yaml
+++ b/config/crd/bases/talos.alperen.cloud_taloscontrolplanes.yaml
@@ -278,15 +278,17 @@ spec:
                 items:
                   type: string
                 type: array
+              preserveMachinesOnDeletion:
+                default: false
+                description: preserveMachinesOnDeletion indicates whether control
+                  plane machines should be preserved (not reset) when deleting this
+                  Kubernetes resource
+                type: boolean
               replicas:
                 description: replicas is the number of control-plane machines to maintain.
                   Only applies when mode is 'container'.
                 format: int32
                 type: integer
-              resetOnDelete:
-                description: resetOnDelete indicates whether deleting this Kubernetes
-                  resource also resets the machines
-                type: boolean
               serviceCIDR:
                 description: serviceCIDR is the list of CIDR ranges for service IPs
                   in the cluster.
@@ -307,7 +309,6 @@ spec:
             required:
             - kubeVersion
             - mode
-            - resetOnDelete
             - version
             type: object
             x-kubernetes-validations:

--- a/config/crd/bases/talos.alperen.cloud_talosmachines.yaml
+++ b/config/crd/bases/talos.alperen.cloud_talosmachines.yaml
@@ -107,6 +107,14 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              deletionPolicy:
+                default: reset
+                description: deletionPolicy specifies the deletion policy for the
+                  machine when deleting this Kubernetes resource (reset or preserve).
+                enum:
+                - reset
+                - preserve
+                type: string
               endpoint:
                 description: endpoint is the Talos API endpoint for this machine.
                 type: string
@@ -188,11 +196,6 @@ spec:
                     description: wipe indicates whether to wipe the disk before installation.
                     type: boolean
                 type: object
-              preserveMachineOnDeletion:
-                default: false
-                description: preserveMachineOnDeletion indicates whether the machine
-                  should be preserved (not reset) when deleting this Kubernetes resource
-                type: boolean
               version:
                 description: version is the desired version of Talos to run on this
                   machine.

--- a/config/crd/bases/talos.alperen.cloud_talosmachines.yaml
+++ b/config/crd/bases/talos.alperen.cloud_talosmachines.yaml
@@ -188,9 +188,10 @@ spec:
                     description: wipe indicates whether to wipe the disk before installation.
                     type: boolean
                 type: object
-              resetOnDelete:
-                description: resetOnDelete indicates whether deleting this Kubernetes
-                  resource also resets the machine
+              preserveMachineOnDeletion:
+                default: false
+                description: preserveMachineOnDeletion indicates whether the machine
+                  should be preserved (not reset) when deleting this Kubernetes resource
                 type: boolean
               version:
                 description: version is the desired version of Talos to run on this
@@ -242,7 +243,6 @@ spec:
                 x-kubernetes-map-type: atomic
             required:
             - endpoint
-            - resetOnDelete
             - version
             type: object
           status:

--- a/config/crd/bases/talos.alperen.cloud_talosmachines.yaml
+++ b/config/crd/bases/talos.alperen.cloud_talosmachines.yaml
@@ -188,6 +188,10 @@ spec:
                     description: wipe indicates whether to wipe the disk before installation.
                     type: boolean
                 type: object
+              resetOnDelete:
+                description: resetOnDelete indicates whether deleting this Kubernetes
+                  resource also resets the machine
+                type: boolean
               version:
                 description: version is the desired version of Talos to run on this
                   machine.
@@ -238,6 +242,7 @@ spec:
                 x-kubernetes-map-type: atomic
             required:
             - endpoint
+            - resetOnDelete
             - version
             type: object
           status:

--- a/config/crd/bases/talos.alperen.cloud_talosworkers.yaml
+++ b/config/crd/bases/talos.alperen.cloud_talosworkers.yaml
@@ -252,16 +252,17 @@ spec:
                 - metal
                 - cloud
                 type: string
+              preserveMachinesOnDeletion:
+                default: false
+                description: preserveMachinesOnDeletion indicates whether worker machines
+                  should be preserved (not reset) when deleting this Kubernetes resource
+                type: boolean
               replicas:
                 default: 1
                 description: replicas is the number of worker machines to maintain.
                   Only applies when mode is 'container'.
                 format: int32
                 type: integer
-              resetOnDelete:
-                description: resetOnDelete indicates whether deleting this Kubernetes
-                  resource also resets the machines
-                type: boolean
               storageClassName:
                 description: storageClassName is the name of the storage class to
                   use for persistent volumes.
@@ -278,7 +279,6 @@ spec:
             required:
             - kubeVersion
             - mode
-            - resetOnDelete
             - version
             type: object
             x-kubernetes-validations:

--- a/config/crd/bases/talos.alperen.cloud_talosworkers.yaml
+++ b/config/crd/bases/talos.alperen.cloud_talosworkers.yaml
@@ -258,6 +258,10 @@ spec:
                   Only applies when mode is 'container'.
                 format: int32
                 type: integer
+              resetOnDelete:
+                description: resetOnDelete indicates whether deleting this Kubernetes
+                  resource also resets the machines
+                type: boolean
               storageClassName:
                 description: storageClassName is the name of the storage class to
                   use for persistent volumes.
@@ -274,6 +278,7 @@ spec:
             required:
             - kubeVersion
             - mode
+            - resetOnDelete
             - version
             type: object
             x-kubernetes-validations:

--- a/config/crd/bases/talos.alperen.cloud_talosworkers.yaml
+++ b/config/crd/bases/talos.alperen.cloud_talosworkers.yaml
@@ -79,6 +79,14 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              deletionPolicy:
+                default: reset
+                description: deletionPolicy specifies the deletion policy for worker
+                  machines when deleting this Kubernetes resource (reset or preserve).
+                enum:
+                - reset
+                - preserve
+                type: string
               kubeVersion:
                 default: v1.35.0
                 description: kubeVersion is the version of Kubernetes to use for the
@@ -252,11 +260,6 @@ spec:
                 - metal
                 - cloud
                 type: string
-              preserveMachinesOnDeletion:
-                default: false
-                description: preserveMachinesOnDeletion indicates whether worker machines
-                  should be preserved (not reset) when deleting this Kubernetes resource
-                type: boolean
               replicas:
                 default: 1
                 description: replicas is the number of worker machines to maintain.

--- a/deploy/talos-operator/templates/crds/talosclusters.yaml
+++ b/deploy/talos-operator/templates/crds/talosclusters.yaml
@@ -290,6 +290,10 @@ spec:
                       to maintain. Only applies when mode is 'container'.
                     format: int32
                     type: integer
+                  resetOnDelete:
+                    description: resetOnDelete indicates whether deleting this Kubernetes
+                      resource also resets the machines
+                    type: boolean
                   serviceCIDR:
                     description: serviceCIDR is the list of CIDR ranges for service
                       IPs in the cluster.
@@ -310,6 +314,7 @@ spec:
                 required:
                 - kubeVersion
                 - mode
+                - resetOnDelete
                 - version
                 type: object
                 x-kubernetes-validations:
@@ -564,6 +569,10 @@ spec:
                       Only applies when mode is 'container'.
                     format: int32
                     type: integer
+                  resetOnDelete:
+                    description: resetOnDelete indicates whether deleting this Kubernetes
+                      resource also resets the machines
+                    type: boolean
                   storageClassName:
                     description: storageClassName is the name of the storage class
                       to use for persistent volumes.
@@ -581,6 +590,7 @@ spec:
                 required:
                 - kubeVersion
                 - mode
+                - resetOnDelete
                 - version
                 type: object
                 x-kubernetes-validations:

--- a/deploy/talos-operator/templates/crds/talosclusters.yaml
+++ b/deploy/talos-operator/templates/crds/talosclusters.yaml
@@ -285,15 +285,17 @@ spec:
                     items:
                       type: string
                     type: array
+                  preserveMachinesOnDeletion:
+                    default: false
+                    description: preserveMachinesOnDeletion indicates whether control
+                      plane machines should be preserved (not reset) when deleting
+                      this Kubernetes resource
+                    type: boolean
                   replicas:
                     description: replicas is the number of control-plane machines
                       to maintain. Only applies when mode is 'container'.
                     format: int32
                     type: integer
-                  resetOnDelete:
-                    description: resetOnDelete indicates whether deleting this Kubernetes
-                      resource also resets the machines
-                    type: boolean
                   serviceCIDR:
                     description: serviceCIDR is the list of CIDR ranges for service
                       IPs in the cluster.
@@ -314,7 +316,6 @@ spec:
                 required:
                 - kubeVersion
                 - mode
-                - resetOnDelete
                 - version
                 type: object
                 x-kubernetes-validations:
@@ -563,16 +564,18 @@ spec:
                     - metal
                     - cloud
                     type: string
+                  preserveMachinesOnDeletion:
+                    default: false
+                    description: preserveMachinesOnDeletion indicates whether worker
+                      machines should be preserved (not reset) when deleting this
+                      Kubernetes resource
+                    type: boolean
                   replicas:
                     default: 1
                     description: replicas is the number of worker machines to maintain.
                       Only applies when mode is 'container'.
                     format: int32
                     type: integer
-                  resetOnDelete:
-                    description: resetOnDelete indicates whether deleting this Kubernetes
-                      resource also resets the machines
-                    type: boolean
                   storageClassName:
                     description: storageClassName is the name of the storage class
                       to use for persistent volumes.
@@ -590,7 +593,6 @@ spec:
                 required:
                 - kubeVersion
                 - mode
-                - resetOnDelete
                 - version
                 type: object
                 x-kubernetes-validations:

--- a/deploy/talos-operator/templates/crds/taloscontrolplanes.yaml
+++ b/deploy/talos-operator/templates/crds/taloscontrolplanes.yaml
@@ -276,15 +276,17 @@ spec:
                 items:
                   type: string
                 type: array
+              preserveMachinesOnDeletion:
+                default: false
+                description: preserveMachinesOnDeletion indicates whether control
+                  plane machines should be preserved (not reset) when deleting this
+                  Kubernetes resource
+                type: boolean
               replicas:
                 description: replicas is the number of control-plane machines to maintain.
                   Only applies when mode is 'container'.
                 format: int32
                 type: integer
-              resetOnDelete:
-                description: resetOnDelete indicates whether deleting this Kubernetes
-                  resource also resets the machines
-                type: boolean
               serviceCIDR:
                 description: serviceCIDR is the list of CIDR ranges for service IPs
                   in the cluster.
@@ -305,7 +307,6 @@ spec:
             required:
             - kubeVersion
             - mode
-            - resetOnDelete
             - version
             type: object
             x-kubernetes-validations:

--- a/deploy/talos-operator/templates/crds/taloscontrolplanes.yaml
+++ b/deploy/talos-operator/templates/crds/taloscontrolplanes.yaml
@@ -281,6 +281,10 @@ spec:
                   Only applies when mode is 'container'.
                 format: int32
                 type: integer
+              resetOnDelete:
+                description: resetOnDelete indicates whether deleting this Kubernetes
+                  resource also resets the machines
+                type: boolean
               serviceCIDR:
                 description: serviceCIDR is the list of CIDR ranges for service IPs
                   in the cluster.
@@ -301,6 +305,7 @@ spec:
             required:
             - kubeVersion
             - mode
+            - resetOnDelete
             - version
             type: object
             x-kubernetes-validations:

--- a/deploy/talos-operator/templates/crds/talosmachines.yaml
+++ b/deploy/talos-operator/templates/crds/talosmachines.yaml
@@ -186,9 +186,10 @@ spec:
                     description: wipe indicates whether to wipe the disk before installation.
                     type: boolean
                 type: object
-              resetOnDelete:
-                description: resetOnDelete indicates whether deleting this Kubernetes
-                  resource also resets the machine
+              preserveMachineOnDeletion:
+                default: false
+                description: preserveMachineOnDeletion indicates whether the machine
+                  should be preserved (not reset) when deleting this Kubernetes resource
                 type: boolean
               version:
                 description: version is the desired version of Talos to run on this
@@ -240,7 +241,6 @@ spec:
                 x-kubernetes-map-type: atomic
             required:
             - endpoint
-            - resetOnDelete
             - version
             type: object
           status:

--- a/deploy/talos-operator/templates/crds/talosmachines.yaml
+++ b/deploy/talos-operator/templates/crds/talosmachines.yaml
@@ -186,6 +186,10 @@ spec:
                     description: wipe indicates whether to wipe the disk before installation.
                     type: boolean
                 type: object
+              resetOnDelete:
+                description: resetOnDelete indicates whether deleting this Kubernetes
+                  resource also resets the machine
+                type: boolean
               version:
                 description: version is the desired version of Talos to run on this
                   machine.
@@ -236,6 +240,7 @@ spec:
                 x-kubernetes-map-type: atomic
             required:
             - endpoint
+            - resetOnDelete
             - version
             type: object
           status:

--- a/deploy/talos-operator/templates/crds/talosworkers.yaml
+++ b/deploy/talos-operator/templates/crds/talosworkers.yaml
@@ -250,16 +250,17 @@ spec:
                 - metal
                 - cloud
                 type: string
+              preserveMachinesOnDeletion:
+                default: false
+                description: preserveMachinesOnDeletion indicates whether worker machines
+                  should be preserved (not reset) when deleting this Kubernetes resource
+                type: boolean
               replicas:
                 default: 1
                 description: replicas is the number of worker machines to maintain.
                   Only applies when mode is 'container'.
                 format: int32
                 type: integer
-              resetOnDelete:
-                description: resetOnDelete indicates whether deleting this Kubernetes
-                  resource also resets the machines
-                type: boolean
               storageClassName:
                 description: storageClassName is the name of the storage class to
                   use for persistent volumes.
@@ -276,7 +277,6 @@ spec:
             required:
             - kubeVersion
             - mode
-            - resetOnDelete
             - version
             type: object
             x-kubernetes-validations:

--- a/deploy/talos-operator/templates/crds/talosworkers.yaml
+++ b/deploy/talos-operator/templates/crds/talosworkers.yaml
@@ -256,6 +256,10 @@ spec:
                   Only applies when mode is 'container'.
                 format: int32
                 type: integer
+              resetOnDelete:
+                description: resetOnDelete indicates whether deleting this Kubernetes
+                  resource also resets the machines
+                type: boolean
               storageClassName:
                 description: storageClassName is the name of the storage class to
                   use for persistent volumes.
@@ -272,6 +276,7 @@ spec:
             required:
             - kubeVersion
             - mode
+            - resetOnDelete
             - version
             type: object
             x-kubernetes-validations:

--- a/internal/controller/taloscontrolplane_controller.go
+++ b/internal/controller/taloscontrolplane_controller.go
@@ -466,10 +466,11 @@ func (r *TalosControlPlaneReconciler) handleTalosMachines(ctx context.Context, t
 					Namespace:  tcp.Namespace,
 					APIVersion: talosv1alpha1.GroupVersion.String(),
 				},
-				Endpoint:    ip,
-				Version:     tcp.Spec.Version,
-				MachineSpec: mergeMachineSpec(tcp.Spec.MetalSpec.MachineSpec, &machine),
-				ConfigRef:   tcp.Spec.ConfigRef,
+				Endpoint:      ip,
+				Version:       tcp.Spec.Version,
+				MachineSpec:   mergeMachineSpec(tcp.Spec.MetalSpec.MachineSpec, &machine),
+				ConfigRef:     tcp.Spec.ConfigRef,
+				ResetOnDelete: tcp.Spec.ResetOnDelete,
 			}
 			return nil
 		})

--- a/internal/controller/taloscontrolplane_controller.go
+++ b/internal/controller/taloscontrolplane_controller.go
@@ -466,11 +466,11 @@ func (r *TalosControlPlaneReconciler) handleTalosMachines(ctx context.Context, t
 					Namespace:  tcp.Namespace,
 					APIVersion: talosv1alpha1.GroupVersion.String(),
 				},
-				Endpoint:      ip,
-				Version:       tcp.Spec.Version,
-				MachineSpec:   mergeMachineSpec(tcp.Spec.MetalSpec.MachineSpec, &machine),
-				ConfigRef:     tcp.Spec.ConfigRef,
-				ResetOnDelete: tcp.Spec.ResetOnDelete,
+				Endpoint:                  ip,
+				Version:                   tcp.Spec.Version,
+				MachineSpec:               mergeMachineSpec(tcp.Spec.MetalSpec.MachineSpec, &machine),
+				ConfigRef:                 tcp.Spec.ConfigRef,
+				PreserveMachineOnDeletion: tcp.Spec.PreserveMachinesOnDeletion,
 			}
 			return nil
 		})

--- a/internal/controller/taloscontrolplane_controller.go
+++ b/internal/controller/taloscontrolplane_controller.go
@@ -466,11 +466,11 @@ func (r *TalosControlPlaneReconciler) handleTalosMachines(ctx context.Context, t
 					Namespace:  tcp.Namespace,
 					APIVersion: talosv1alpha1.GroupVersion.String(),
 				},
-				Endpoint:                  ip,
-				Version:                   tcp.Spec.Version,
-				MachineSpec:               mergeMachineSpec(tcp.Spec.MetalSpec.MachineSpec, &machine),
-				ConfigRef:                 tcp.Spec.ConfigRef,
-				PreserveMachineOnDeletion: tcp.Spec.PreserveMachinesOnDeletion,
+				Endpoint:       ip,
+				Version:        tcp.Spec.Version,
+				MachineSpec:    mergeMachineSpec(tcp.Spec.MetalSpec.MachineSpec, &machine),
+				ConfigRef:      tcp.Spec.ConfigRef,
+				DeletionPolicy: tcp.Spec.DeletionPolicy,
 			}
 			return nil
 		})

--- a/internal/controller/talosmachine_controller.go
+++ b/internal/controller/talosmachine_controller.go
@@ -428,20 +428,23 @@ func (r *TalosMachineReconciler) handleDelete(ctx context.Context, tm *talosv1al
 	if tm.Status.State == talosv1alpha1.StateOrphaned {
 		return ctrl.Result{}, nil
 	}
-	// Run talosctl reset command to reset the machine
-	config, err := r.GetBundleConfig(ctx, tm)
-	if err != nil {
-		return ctrl.Result{Requeue: true}, fmt.Errorf("failed to get BundleConfig for TalosMachine %s: %w", tm.Name, err)
-	}
-	// Make the client for the machine
-	config.ClientEndpoint = &[]string{tm.Spec.Endpoint}
-	tc, err := talos.NewClient(config, false)
-	if err != nil {
-		return ctrl.Result{Requeue: true}, fmt.Errorf("failed to create Talos client for TalosMachine %s: %w", tm.Name, err)
-	}
-	defer tc.Close() //nolint:errcheck
-	if err := tc.Reset(ctx, false, true); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to reset TalosMachine %s: %w", tm.Name, err)
+	// Only reset if requested:
+	if tm.Spec.ResetOnDelete {
+		// Run talosctl reset command to reset the machine
+		config, err := r.GetBundleConfig(ctx, tm)
+		if err != nil {
+			return ctrl.Result{Requeue: true}, fmt.Errorf("failed to get BundleConfig for TalosMachine %s: %w", tm.Name, err)
+		}
+		// Make the client for the machine
+		config.ClientEndpoint = &[]string{tm.Spec.Endpoint}
+		tc, err := talos.NewClient(config, false)
+		if err != nil {
+			return ctrl.Result{Requeue: true}, fmt.Errorf("failed to create Talos client for TalosMachine %s: %w", tm.Name, err)
+		}
+		defer tc.Close() //nolint:errcheck
+		if err := tc.Reset(ctx, false, true); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to reset TalosMachine %s: %w", tm.Name, err)
+		}
 	}
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/talosmachine_controller.go
+++ b/internal/controller/talosmachine_controller.go
@@ -428,8 +428,8 @@ func (r *TalosMachineReconciler) handleDelete(ctx context.Context, tm *talosv1al
 	if tm.Status.State == talosv1alpha1.StateOrphaned {
 		return ctrl.Result{}, nil
 	}
-	// Do not reset if the machine must be preserved on deletion:
-	if !tm.Spec.PreserveMachineOnDeletion {
+	// Only reset if requested by deletion policy:
+	if tm.Spec.DeletionPolicy == "reset" {
 		// Run talosctl reset command to reset the machine
 		config, err := r.GetBundleConfig(ctx, tm)
 		if err != nil {

--- a/internal/controller/talosmachine_controller.go
+++ b/internal/controller/talosmachine_controller.go
@@ -428,8 +428,8 @@ func (r *TalosMachineReconciler) handleDelete(ctx context.Context, tm *talosv1al
 	if tm.Status.State == talosv1alpha1.StateOrphaned {
 		return ctrl.Result{}, nil
 	}
-	// Only reset if requested:
-	if tm.Spec.ResetOnDelete {
+	// Do not reset if the machine must be preserved on deletion:
+	if !tm.Spec.PreserveMachineOnDeletion {
 		// Run talosctl reset command to reset the machine
 		config, err := r.GetBundleConfig(ctx, tm)
 		if err != nil {

--- a/internal/controller/talosworker_controller.go
+++ b/internal/controller/talosworker_controller.go
@@ -272,10 +272,11 @@ func (r *TalosWorkerReconciler) handleTalosMachines(ctx context.Context, tw *tal
 					Namespace:  tw.Namespace,
 					APIVersion: talosv1alpha1.GroupVersion.String(),
 				},
-				Endpoint:    ip,
-				Version:     tw.Spec.Version,
-				MachineSpec: mergeMachineSpec(tw.Spec.MetalSpec.MachineSpec, &machine),
-				ConfigRef:   tw.Spec.ConfigRef,
+				Endpoint:      ip,
+				Version:       tw.Spec.Version,
+				MachineSpec:   mergeMachineSpec(tw.Spec.MetalSpec.MachineSpec, &machine),
+				ConfigRef:     tw.Spec.ConfigRef,
+				ResetOnDelete: tw.Spec.ResetOnDelete,
 			}
 			return nil
 		})

--- a/internal/controller/talosworker_controller.go
+++ b/internal/controller/talosworker_controller.go
@@ -272,11 +272,11 @@ func (r *TalosWorkerReconciler) handleTalosMachines(ctx context.Context, tw *tal
 					Namespace:  tw.Namespace,
 					APIVersion: talosv1alpha1.GroupVersion.String(),
 				},
-				Endpoint:      ip,
-				Version:       tw.Spec.Version,
-				MachineSpec:   mergeMachineSpec(tw.Spec.MetalSpec.MachineSpec, &machine),
-				ConfigRef:     tw.Spec.ConfigRef,
-				ResetOnDelete: tw.Spec.ResetOnDelete,
+				Endpoint:                  ip,
+				Version:                   tw.Spec.Version,
+				MachineSpec:               mergeMachineSpec(tw.Spec.MetalSpec.MachineSpec, &machine),
+				ConfigRef:                 tw.Spec.ConfigRef,
+				PreserveMachineOnDeletion: tw.Spec.PreserveMachinesOnDeletion,
 			}
 			return nil
 		})

--- a/internal/controller/talosworker_controller.go
+++ b/internal/controller/talosworker_controller.go
@@ -272,11 +272,11 @@ func (r *TalosWorkerReconciler) handleTalosMachines(ctx context.Context, tw *tal
 					Namespace:  tw.Namespace,
 					APIVersion: talosv1alpha1.GroupVersion.String(),
 				},
-				Endpoint:                  ip,
-				Version:                   tw.Spec.Version,
-				MachineSpec:               mergeMachineSpec(tw.Spec.MetalSpec.MachineSpec, &machine),
-				ConfigRef:                 tw.Spec.ConfigRef,
-				PreserveMachineOnDeletion: tw.Spec.PreserveMachinesOnDeletion,
+				Endpoint:       ip,
+				Version:        tw.Spec.Version,
+				MachineSpec:    mergeMachineSpec(tw.Spec.MetalSpec.MachineSpec, &machine),
+				ConfigRef:      tw.Spec.ConfigRef,
+				DeletionPolicy: tw.Spec.DeletionPolicy,
 			}
 			return nil
 		})


### PR DESCRIPTION
By default, deleting a TalosMachine resource sends a "reset" command to the machine. This could be dangerous if the resource is being deleted by mistake.

This PR adds a new field named "preserveMachineOnDeletion" on the TalosMachine CRD and "preserveMachinesOnDeletion" on TalosControlPlane/Worker CRDs that specifies whether the machine should be preserved or reset when its resource is deleted.