### PR TITLE
feat: Custom metrics port

### DIFF
--- a/deploy/talos-operator/templates/deployment.yaml
+++ b/deploy/talos-operator/templates/deployment.yaml
@@ -40,8 +40,9 @@ spec:
             {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.tracing.enabled }}
           args:
+            - "--metrics-bind-address=:{{ .Values.service.port }}"
+          {{- if .Values.tracing.enabled }}
             - --enable-tracing
             - --otlp-endpoint={{ .Values.tracing.otlpEndpoint }}
           {{- end }}


### PR DESCRIPTION
This PR adds support for setting a custom port for the metrics.

When PXE boot stack is enabled, hostNetwork is enabled as well, so setting a custom port prevents conflicts with another process listening on the same port.