### PR TITLE
fix: Make dnsmasq only listen to the interfaces specified in the TalosCluster resources.

### DIFF
--- a/internal/controller/templates/dnsmasq-config.conf
+++ b/internal/controller/templates/dnsmasq-config.conf
@@ -18,8 +18,9 @@ dhcp-boot=tag:efi-arm64,ipxe-efi-arm64.efi
 # Tagging iPXE clients:
 dhcp-userclass=set:ipxe,iPXE
 
-{{ range . }}
+{{- range . }}
 # {{ .Name }}
+interface={{ .PxeInterface }}
 tag-if=set:if_{{ .PxeInterface }},tag:{{ .PxeInterface }}
 dhcp-range=tag:if_{{ .PxeInterface }},{{ .PxeIpAddress }},static
 dhcp-boot=tag:if_{{ .PxeInterface }},tag:ipxe,http://{{ .PxeIpAddress }}:{{ .MatchboxPort }}/boot.ipxe
@@ -27,4 +28,4 @@ dhcp-boot=tag:if_{{ .PxeInterface }},tag:ipxe,http://{{ .PxeIpAddress }}:{{ .Mat
 {{- range .Machines }}
 dhcp-host=tag:if_{{ $PxeInterface }},{{ .MacAddress }},{{ .IpAddress }}
 {{- end }}
-{{- end }}
+{{ end }}


### PR DESCRIPTION
By default, dnsmasq listens to all the host interfaces.

This PR limits the interfaces dnsmasq listen to to only the interfaces specified in the TalosCluster resources.