### PR TITLE
fix: Avoid restarting dnsmasq if its configuration did not change.

### DIFF
--- a/internal/controller/cluster_common.go
+++ b/internal/controller/cluster_common.go
@@ -127,20 +127,22 @@ func updatePxeBootStackConfig(clusters []Cluster) error {
 
 	// Generating configurations from templates and saving to files
 	// dnsmasq
-	if err := generateConfiguration(dnsmasqConfigTmpl, DnsmasqConfigPath, clusters); err != nil {
+	configChanged, err := generateConfiguration(dnsmasqConfigTmpl, DnsmasqConfigPath, clusters)
+	if err != nil {
 		return err
 	}
 	// Matchbox
+	// Does not need to be restarted, so we don't have to check if its config changed
 	for _, c := range clusters {
 		for _, m := range c.Machines {
 			// Groups
-			if err := generateConfiguration(matchboxGroupTmpl,
+			if _, err := generateConfiguration(matchboxGroupTmpl,
 				path.Join(MatchboxConfigPath, MatchboxGroupsDir, fmt.Sprintf("%s.json", m.Id)), m,
 			); err != nil {
 				return err
 			}
 			// Profiles
-			if err := generateConfiguration(matchboxProfileTmpl,
+			if _, err := generateConfiguration(matchboxProfileTmpl,
 				path.Join(MatchboxConfigPath, MatchboxProfilesDir, fmt.Sprintf("%s.json", m.Id)), m,
 			); err != nil {
 				return err
@@ -148,26 +150,50 @@ func updatePxeBootStackConfig(clusters []Cluster) error {
 		}
 	}
 
+	// Restart PXE boot stack to apply the new configuration, if necessary
+	if configChanged {
+		if err := restartPxeBootStack(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
-func generateConfiguration(tmplString string, destPath string, data any) error {
+func generateConfiguration(tmplString string, destPath string, data any) (bool, error) {
+	// Saving current config to check if it changed
+	configChanged := false
+	content, err := os.ReadFile(DnsmasqConfigPath)
+	if err != nil {
+		return configChanged, err
+	}
+	previousConfig := string(content)
+
 	file, err := os.Create(destPath)
 	if err != nil {
-		return err
+		return configChanged, err
 	}
 	tmpl, err := template.New("").Parse(tmplString)
 	if err != nil {
-		return err
+		return configChanged, err
 	}
 	if err := tmpl.Execute(file, data); err != nil {
-		return err
+		return configChanged, err
 	}
 	if err := file.Close(); err != nil {
-		return err
+		return configChanged, err
 	}
 
-	return nil
+	// Checking if config changed
+	content, err = os.ReadFile(DnsmasqConfigPath)
+	if err != nil {
+		return configChanged, err
+	}
+	if string(content) != previousConfig {
+		configChanged = true
+	}
+
+	return configChanged, nil
 }
 
 func downloadBootImages(clusters []Cluster) error {

--- a/internal/controller/taloscluster_controller.go
+++ b/internal/controller/taloscluster_controller.go
@@ -338,11 +338,6 @@ func (r *TalosClusterReconciler) handlePxeBootStack(ctx context.Context, tc talo
 		return err
 	}
 
-	// Restart PXE boot stack to apply the new configuration
-	if err := restartPxeBootStack(); err != nil {
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
The operator restarts dnsmasq every time it tries to reconcile a TalosCluster resource, if PXE boot stack is enabled. This results in a "CrashLoopBackoff" for the dnsmasq container, since the restarts happen repeatedly. On top of that, it generates multiple errors as the operator cannot find the dnsmasq process when it wants to restart it, as it didn't finish restarting from the previous attempt.

This PR adds a check to prevent the operator from restarting dnsmasq if its configuration didn't change.