### PR TITLE
fix: Reflect CNI field from TalosCluster to TalosControlPlane.

### DIFF
--- a/internal/controller/taloscluster_controller.go
+++ b/internal/controller/taloscluster_controller.go
@@ -176,6 +176,7 @@ func (r *TalosClusterReconciler) reconcileControlPlane(ctx context.Context, tc *
 				ServiceCIDR:      tc.Spec.ControlPlane.ServiceCIDR,
 				DeletionPolicy:   tc.Spec.ControlPlane.DeletionPolicy,
 				RolloutStrategy:  tc.Spec.ControlPlane.RolloutStrategy,
+				CNI:              tc.Spec.ControlPlane.CNI,
 			}
 			// Optionally set ConfigRef if provided
 			if tc.Spec.ControlPlane.ConfigRef != nil {


### PR DESCRIPTION
This PR makes the CNI field from the `controlPlane` section of the TalosCluster resource to be reflected to the generated TalosControlPlane resource. This field would be ignored otherwise.