### PR TITLE
fix: Do not re-get the machine object to prevent overwriting state.

### DIFF
--- a/internal/controller/talosmachine_controller.go
+++ b/internal/controller/talosmachine_controller.go
@@ -174,10 +174,6 @@ func (r *TalosMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			return res, nil // Requeue the reconciliation to check the machine status again
 		}
 	}
-	// Re-get the machine object to ensure we have the latest state
-	if err := r.Get(ctx, req.NamespacedName, &talosMachine); err != nil {
-		return ctrl.Result{}, r.handleResourceNotFound(ctx, err)
-	}
 
 	// Check if feature flag for meta key is enabled and handle it
 	if os.Getenv("ENABLE_META_KEY") == "true" {


### PR DESCRIPTION
In the reconciliation function of a machine object, when checking a machine's boot status after the machine has finished booting, the state switches to "Pending" and the function continues.

However, by re-getting the machine object afterward, the operator overwrites the new state in memory and thus thinks the machine is still "Booting". This is probably because the new state isn't yet written on the actual resource, so re-getting the resource returns the previous state.

This PR fixes the issue by not re-getting the object, as the new state is still in memory anyway.