### PR TITLE
fix: better docs + additionalConfig YAML fix

### DIFF
--- a/docs/crds/index.md
+++ b/docs/crds/index.md
@@ -1,17 +1,41 @@
 # Custom Resource Definitions (CRDs)
 
-This section provides detailed documentation for the Custom Resource Definitions (CRDs) used by the Talos Operator. CRDs are extensions of the Kubernetes API that allow you to manage custom resources. In the context of the Talos Operator, these resources are used to define and manage Talos clusters in a declarative way.
+The Talos Operator defines the following CRDs in the `talos.alperen.cloud/v1alpha1` API group. All resources are namespaced.
 
-Here you will find information on the following CRDs:
+## Core Resources
 
-*   [TalosCluster](./taloscluster.md)
-*   [TalosControlPlane](./taloscontrolplane.md)
-*   [TalosWorker](./talosworker.md)
-*   [TalosMachine](./talosmachine.md)
-*   [TalosEtcdBackup](./talosetcdbackup.md)
-*   [TalosEtcdBackupSchedule](./talosetcdbackupschedule.md)
-*   [TalosClusterAddon](./talosclusteraddon.md)
-*   [TalosClusterAddonRelease](./talosclusteraddonrelease.md)
+| CRD | Short Name | Description |
+|-----|-----------|-------------|
+| [TalosCluster](./taloscluster.md) | `tc` | Top-level resource that composes a Talos cluster from a control plane and worker nodes. |
+| [TalosControlPlane](./taloscontrolplane.md) | `tcp` | Defines and manages the control plane of a Talos cluster. |
+| [TalosWorker](./talosworker.md) | `tw` | Defines and manages the worker nodes of a Talos cluster. |
+| [TalosMachine](./talosmachine.md) | `tm` | Represents a single Talos machine. Auto-managed by the operator in `metal` mode. |
 
+## Backup Resources
 
+| CRD | Short Name | Description |
+|-----|-----------|-------------|
+| [TalosEtcdBackup](./talosetcdbackup.md) | `teb` | One-time etcd backup streamed to S3-compatible storage. |
+| [TalosEtcdBackupSchedule](./talosetcdbackupschedule.md) | `tebs` | Cron-based scheduled etcd backups with retention management. |
 
+## Addon Resources
+
+| CRD | Short Name | Description |
+|-----|-----------|-------------|
+| [TalosClusterAddon](./talosclusteraddon.md) | `tca` | Helm chart addon applied to clusters matching a label selector. |
+| [TalosClusterAddonRelease](./talosclusteraddonrelease.md) | `tcar` | Per-cluster Helm release instance (auto-managed by `TalosClusterAddon`). |
+
+## Resource Relationships
+
+```
+TalosCluster
+ ├── TalosControlPlane (inline or ref)
+ │    ├── TalosMachine (metal mode, auto-created)
+ │    ├── TalosEtcdBackupSchedule
+ │    │    └── TalosEtcdBackup (auto-created per schedule)
+ │    └── TalosEtcdBackup (manual)
+ ├── TalosWorker (inline or ref)
+ │    └── TalosMachine (metal mode, auto-created)
+ └── TalosClusterAddon
+      └── TalosClusterAddonRelease (auto-created per matched cluster)
+```

--- a/docs/crds/taloscluster.md
+++ b/docs/crds/taloscluster.md
@@ -1,10 +1,22 @@
 # TalosCluster
 
-`TalosCluster` is a custom resource definition (CRD) used to define a Talos Linux cluster in a Kubernetes environment. It allows users to specify the configuration and desired state of a Talos cluster, including the number of control plane and worker nodes, networking settings, and other cluster parameters. `TalosCluster` is breaking the cluster into two parts: the `TalosControlPlane` and the `TalosWorker`. You can either define them inline or you can refer to them by name.
+| Field | Value |
+|-------|-------|
+| **API Group** | `talos.alperen.cloud` |
+| **API Version** | `v1alpha1` |
+| **Kind** | `TalosCluster` |
+| **Short Names** | `tc` |
+| **Scope** | Namespaced |
+| **Subresources** | `status` |
 
-## Creating your first TalosCluster
+`TalosCluster` is the top-level CRD that defines a complete Talos Linux cluster. It composes a `TalosControlPlane` and `TalosWorker` into a single resource. You can either define them **inline** (embedded directly) or **by reference** (pointing to separately managed resources).
 
-To create your first `TalosCluster` as container mode, you can use the following example YAML manifest:
+!!!warning
+    Mixing modes (e.g. `container` control plane with `metal` workers) is highly discouraged and may lead to unexpected behavior.
+
+---
+
+## Example
 
 ```yaml
 apiVersion: talos.alperen.cloud/v1alpha1
@@ -15,7 +27,7 @@ spec:
   controlPlane:
     version: v1.13.0
     mode: container
-    replicas: 2
+    replicas: 3
     kubeVersion: v1.35.0
   worker:
     version: v1.13.0
@@ -24,21 +36,53 @@ spec:
     kubeVersion: v1.35.0
 ```
 
-This manifest defines a `TalosCluster` named `taloscluster-sample` with the following specifications:
+---
 
-- **Control Plane**:
-  - Version: `v1.13.0` (Talos version)
-  - Mode: `container` (running Talos as a container in Kubernetes)
-  - Replicas: `2` (two control plane nodes)
-  - Kubernetes Version: `v1.33.0`
-- **Worker Nodes**:
-  - Version: `v1.13.0` (Talos version)
-  - Mode: `container` (running Talos as a container in Kubernetes)
-  - Replicas: `2` (two worker nodes)
-  - Kubernetes Version: `v1.33.0`
+## Spec Fields
 
-!!!tip
-    For more examples please refer to [examples](https://github.com/alperencelik/talos-operator/tree/main/examples) directory in the repository.
+### `spec` (TalosClusterSpec)
 
-!!!warning
-    Mixing modes is highly discouraged. You should either use `container` mode for both control plane and worker nodes or `metal` mode for both. Mixing modes can lead to unexpected behavior and it's not fully supported. If you want to run Talos on bare metal or virtual machines, you should use the `metal` mode for both control plane and worker nodes.
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `controlPlane` | [TalosControlPlaneSpec](./taloscontrolplane.md#spec-fields) | No | - | Inline control plane configuration. Mutually exclusive with `controlPlaneRef`. |
+| `controlPlaneRef` | [LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#localobjectreference-v1-core) | No | - | Reference to an existing `TalosControlPlane` resource by name. Mutually exclusive with `controlPlane`. |
+| `worker` | [TalosWorkerSpec](./talosworker.md#spec-fields) | No | - | Inline worker configuration. Mutually exclusive with `workerRef`. |
+| `workerRef` | [LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#localobjectreference-v1-core) | No | - | Reference to an existing `TalosWorker` resource by name. Mutually exclusive with `worker`. |
+| `pxeServerSpec` | [PxeServerSpec](#pxeserverspec) | No | - | PXE server configuration for network booting Talos machines. |
+
+### Cross-Field Validations
+
+| Rule | Message |
+|------|---------|
+| `!(has(controlPlane) && has(controlPlaneRef))` | Specify either controlPlane or controlPlaneRef, but not both |
+| `!(has(worker) && has(workerRef))` | Specify either worker or workerRef, but not both |
+
+---
+
+## Nested Types
+
+### PxeServerSpec
+
+Defines the PXE server used for booting Talos over the network.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `address` | string | Yes | - | IP address of the PXE server. Must match pattern `^(\d{1,3}\.){3}\d{1,3}$`. |
+| `interface` | string | Yes | - | Network interface on the PXE server connected to the boot network (Linux interface name, e.g. `eth0`). |
+
+---
+
+## Status Fields
+
+### `status` (TalosClusterStatus)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `conditions` | [][Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta) | List of conditions representing the current state of the TalosCluster. |
+
+#### Condition Types
+
+| Type | Description |
+|------|-------------|
+| `Ready` | The cluster and all its components are fully reconciled and healthy. |
+| `Progressing` | The cluster is being created, updated, or upgraded. |

--- a/docs/crds/talosclusteraddon.md
+++ b/docs/crds/talosclusteraddon.md
@@ -1,6 +1,25 @@
 # TalosClusterAddon
 
-`TalosClusterAddon` is a Custom Resource Definition (CRD) that allows you to define addons (Helm charts) that should be installed on a set of Talos clusters. It uses a label selector to match target clusters.
+| Field | Value |
+|-------|-------|
+| **API Group** | `talos.alperen.cloud` |
+| **API Version** | `v1alpha1` |
+| **Kind** | `TalosClusterAddon` |
+| **Short Names** | `tca` |
+| **Scope** | Namespaced |
+| **Subresources** | `status` |
+
+`TalosClusterAddon` defines a Helm chart addon that should be installed on a set of Talos clusters matched by a label selector. The controller automatically creates a `TalosClusterAddonRelease` for each matching cluster.
+
+## Print Columns
+
+| Name | JSON Path |
+|------|-----------|
+| Chart | `.spec.helmSpec.chartName` |
+| Version | `.spec.helmSpec.version` |
+| Age | `.metadata.creationTimestamp` |
+
+---
 
 ## Example
 
@@ -8,7 +27,7 @@
 apiVersion: talos.alperen.cloud/v1alpha1
 kind: TalosClusterAddon
 metadata:
-  name: example-addon
+  name: ingress-nginx-addon
 spec:
   clusterSelector:
     matchLabels:
@@ -18,40 +37,65 @@ spec:
     repoURL: https://kubernetes.github.io/ingress-nginx
     releaseName: ingress-nginx
     namespace: ingress-nginx
-    version: 4.0.13
+    version: 4.12.1
     valuesTemplate: |
       controller:
         replicaCount: 2
+        service:
+          type: LoadBalancer
+    options:
+      wait: true
+      timeout: 300
+      skipCRDs: false
+    credentials:
+      secret:
+        name: helm-credentials
+    tlsConfig:
+      secret:
+        name: helm-tls
 ```
 
-## Spec
+---
 
-### `clusterSelector`
+## Spec Fields
 
-A standard Kubernetes LabelSelector that matches the `TalosControlPlane` resources where this addon should be installed.
+### `spec` (TalosClusterAddonSpec)
 
-### `helmSpec`
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `clusterSelector` | [LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#labelselector-v1-meta) | No | - | Label selector matching `TalosCluster` resources where this addon should be installed. |
+| `helmSpec` | [HelmSpec](#helmspec) | No | - | Helm chart configuration. |
 
-Configuration for the Helm chart.
+### HelmSpec
+
+Configuration for the Helm chart release.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `chartName` | string | Yes | - | Name of the Helm chart in the repository. e.g. for `oci://repo-url/chart-name`, this is `chart-name`. |
+| `repoURL` | string | Yes | - | URL of the Helm chart repository. e.g. for `oci://repo-url/chart-name`, this is `oci://repo-url`. Supports both `https://` and `oci://` schemes. |
+| `releaseName` | string | No | Auto-generated | Helm release name. If omitted, a name is generated. |
+| `namespace` | string | No | `default` | Kubernetes namespace where the Helm release will be installed on each matched cluster. |
+| `version` | string | No | Latest | Helm chart version. If omitted, the latest available version is used and kept up to date. |
+| `valuesTemplate` | string | No | - | Inline YAML with Helm values. Supports Go templating to reference fields from each matched workload Cluster. |
+| `options` | *[HelmOptions](https://pkg.go.dev/sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1#HelmOptions) | No | - | CLI flags for Helm operations (install, upgrade, delete). Includes `wait`, `skipCRDs`, `timeout`, `waitForJobs`, etc. Inherited from Cluster API Addons. |
+| `credentials` | *[Credentials](https://pkg.go.dev/sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1#Credentials) | No | - | OCI registry credentials reference. Inherited from Cluster API Addons. |
+| `tlsConfig` | *[TLSConfig](https://pkg.go.dev/sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1#TLSConfig) | No | - | TLS configuration for the Helm repository. Inherited from Cluster API Addons. |
+
+---
+
+## Status Fields
+
+### `status` (TalosClusterAddonStatus)
 
 | Field | Type | Description |
-|Data | Type | Description |
-|---|---|---|
-| `chartName` | string | Name of the Helm chart. |
-| `repoURL` | string | URL of the Helm chart repository. |
-| `releaseName` | string | (Optional) Name of the release. Generated if not provided. |
-| `namespace` | string | (Optional) Namespace to install the release into. Defaults to `default`. |
-| `version` | string | (Optional) Version of the chart. Defaults to latest. |
-| `valuesTemplate` | string | (Optional) Inline YAML values for the chart. |
+|-------|------|-------------|
+| `conditions` | [][Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta) | List of conditions. Map-list keyed by `type`. |
 
-## Status
+#### Condition Types
 
-The `status` section reflects the current state of the addon.
-
-### Conditions
-
-| Type | Status | Reason | Message |
-|---|---|---|---|
-| `Ready` | `True` | `Reconciled` | The addon has been successfully processed and `TalosClusterAddonRelease` resources have been created for all matching clusters. |
+| Type | Status | Reason | Description |
+|------|--------|--------|-------------|
+| `Ready` | `True` | `Reconciled` | Addon processed and `TalosClusterAddonRelease` resources created for all matching clusters. |
 | `Ready` | `False` | `ListClustersFailed` | Failed to list matching clusters. |
 | `Ready` | `False` | `CreateOrUpdateReleaseFailed` | Failed to create or update a release for one or more clusters. |

--- a/docs/crds/talosclusteraddonrelease.md
+++ b/docs/crds/talosclusteraddonrelease.md
@@ -1,10 +1,28 @@
 # TalosClusterAddonRelease
 
-`TalosClusterAddonRelease` represents a specific installation of a Helm chart on a single Talos cluster. It is typically created and managed automatically by the `TalosClusterAddon` controller, but can also be created manually.
+| Field | Value |
+|-------|-------|
+| **API Group** | `talos.alperen.cloud` |
+| **API Version** | `v1alpha1` |
+| **Kind** | `TalosClusterAddonRelease` |
+| **Short Names** | `tcar` |
+| **Scope** | Namespaced |
+| **Subresources** | `status` |
 
+`TalosClusterAddonRelease` represents a specific Helm chart installation on a single Talos cluster. It is created automatically by the `TalosClusterAddon` controller for each matched cluster, but can also be created manually.
 
 !!!warning
-    This resource is not intended to be created manually. It is created automatically by the `TalosClusterAddon` controller but not enforced. Please consider managing the `TalosClusterAddon` instead.
+    This resource is not intended to be created manually. It is managed automatically by the `TalosClusterAddon` controller. Use `TalosClusterAddon` for addon management.
+
+## Print Columns
+
+| Name | JSON Path |
+|------|-----------|
+| Cluster | `.spec.clusterRef.name` |
+| Chart | `.spec.helmSpec.chartName` |
+| Age | `.metadata.creationTimestamp` |
+
+---
 
 ## Example
 
@@ -12,7 +30,7 @@
 apiVersion: talos.alperen.cloud/v1alpha1
 kind: TalosClusterAddonRelease
 metadata:
-  name: example-cluster-example-addon-addonrelease
+  name: example-cluster-ingress-nginx
 spec:
   clusterRef:
     name: example-cluster
@@ -22,32 +40,44 @@ spec:
     repoURL: https://kubernetes.github.io/ingress-nginx
     releaseName: ingress-nginx
     namespace: ingress-nginx
+    version: 4.12.1
 ```
 
-## Spec
+---
 
-### `clusterRef`
+## Spec Fields
 
-Reference to the `TalosControlPlane` where the addon is installed.
+### `spec` (TalosClusterAddonReleaseSpec)
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `clusterRef` | [ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectreference-v1-core) | Yes | - | Reference to the `TalosControlPlane` (or `TalosCluster`) where the addon will be installed. |
+| `helmSpec` | [HelmSpec](./talosclusteraddon.md#helmspec) | No | - | Helm chart configuration. Uses the same `HelmSpec` type as `TalosClusterAddon`. |
+
+### `clusterRef` Fields
 
 | Field | Type | Description |
-|---|---|---|
-| `name` | string | Name of the cluster. |
-| `namespace` | string | Namespace of the cluster. |
+|-------|------|-------------|
+| `name` | string | Name of the target cluster resource. |
+| `namespace` | string | Namespace of the target cluster resource. |
+| `kind` | string | Kind of the target resource (e.g. `TalosControlPlane`). |
+| `apiVersion` | string | API version of the target resource. |
 
-### `helmSpec`
+---
 
-Configuration for the Helm chart (same as `TalosClusterAddon`).
+## Status Fields
 
-## Status
+### `status` (TalosClusterAddonReleaseStatus)
 
-The `status` section reflects the installation state of the Helm chart.
+| Field | Type | Description |
+|-------|------|-------------|
+| `conditions` | [][Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta) | List of conditions. Map-list keyed by `type`. |
 
-### Conditions
+#### Condition Types
 
-| Type | Status | Reason | Message |
-|---|---|---|---|
-| `Ready` | `True` | `Installed` | The Helm chart has been successfully installed or upgraded. |
+| Type | Status | Reason | Description |
+|------|--------|--------|-------------|
+| `Ready` | `True` | `Installed` | Helm chart successfully installed or upgraded. |
 | `Ready` | `False` | `KubeconfigFailed` | Failed to retrieve kubeconfig for the target cluster. |
 | `Ready` | `False` | `HelmClientFailed` | Failed to create the Helm client. |
 | `Ready` | `False` | `HelmInstallFailed` | Failed to install or upgrade the Helm chart. |

--- a/docs/crds/taloscontrolplane.md
+++ b/docs/crds/taloscontrolplane.md
@@ -1,14 +1,233 @@
 # TalosControlPlane
 
-`TalosControlPlane` is a custom resource definition (CRD) used to define the control plane of a Talos Linux cluster in a Kubernetes environment. It allows users to specify the configuration and desired state of the control plane, including the number of control plane nodes, networking settings, and other parameters specific to the control plane. `TalosControlPlane` might be owned by a `TalosCluster` resource, which manages the overall cluster configuration but also can be defined independently to allow users flexibility in their deployment methods. The `TalosControlPlane` CRD is essential for managing the control plane nodes, ensuring they are correctly configured and maintained according to the specified parameters. It's also place that Talos API secrets are stored, which are used to authenticate and manage the operations via Talos API.
+| Field | Value |
+|-------|-------|
+| **API Group** | `talos.alperen.cloud` |
+| **API Version** | `v1alpha1` |
+| **Kind** | `TalosControlPlane` |
+| **Short Names** | `tcp` |
+| **Scope** | Namespaced |
+| **Subresources** | `status` |
+
+`TalosControlPlane` defines the control plane of a Talos Linux cluster. It manages the lifecycle of control plane nodes including provisioning, configuration, upgrades, and secrets. It can be owned by a `TalosCluster` or managed independently.
+
+## Print Columns
+
+| Name | JSON Path |
+|------|-----------|
+| State | `.status.state` |
+| Version | `.spec.version` |
+| KubeVersion | `.spec.kubeVersion` |
+| Mode | `.spec.mode` |
+| Age | `.metadata.creationTimestamp` |
+
+---
 
 ## Modes
 
-The `TalosControlPlane` can be defined in two modes:
+| Mode | Description |
+|------|-------------|
+| `container` | Runs Talos control plane as containers within Kubernetes pods. Requires `replicas`. |
+| `metal` | Runs Talos on bare metal or virtual machines. Requires `metalSpec.machines`. |
+| `cloud` | Reserved for future cloud provider integration. |
 
-- **Container**: This mode allows the control plane to run as a containers within a Kubernetes pod. Thankfully, Talos is compatible to run as Kubernetes in Kubernetes mode so you can run TalosControlPlane as a pod in a Kubernetes cluster. 
+---
 
-- **Metal**: This mode allows the control plane to run directly on bare metal or virtual machines. In this mode, the TalosControlPlane is responsible for managing the lifecycle of the control plane nodes, including installation, configuration, and updates. This is useful for scenarios where you want to run Talos on dedicated hardware or virtual machines outside of Kubernetes.
+## Example
 
-!!!tip
-    For more examples please refer to [examples](https://github.com/alperencelik/talos-operator/tree/main/examples) directory in the repository.
+### Container Mode
+
+```yaml
+apiVersion: talos.alperen.cloud/v1alpha1
+kind: TalosControlPlane
+metadata:
+  name: my-controlplane
+spec:
+  version: v1.13.0
+  mode: container
+  replicas: 3
+  kubeVersion: v1.35.0
+  clusterDomain: cluster.local
+  podCIDR:
+    - 10.244.0.0/16
+  serviceCIDR:
+    - 10.96.0.0/12
+  cni:
+    name: flannel
+    flannel:
+      kubeNetworkPoliciesEnabled: true
+  storageClassName: standard
+  deletionPolicy: reset
+```
+
+### Metal Mode
+
+```yaml
+apiVersion: talos.alperen.cloud/v1alpha1
+kind: TalosControlPlane
+metadata:
+  name: my-controlplane
+spec:
+  version: v1.13.0
+  mode: metal
+  kubeVersion: v1.35.0
+  endpoint: https://192.168.1.100:6443
+  metalSpec:
+    machines:
+      - address: "192.168.1.101"
+        pxeClientSpec:
+          macAddress: "00:11:22:33:44:55"
+          cpuArchitecture: amd64
+      - address: "192.168.1.102"
+        pxeClientSpec:
+          macAddress: "00:11:22:33:44:66"
+          cpuArchitecture: amd64
+    machineSpec:
+      installDisk: /dev/sda
+      wipe: false
+  rolloutStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+```
+
+---
+
+## Spec Fields
+
+### `spec` (TalosControlPlaneSpec)
+
+| Field | Type | Required | Default | Validation | Description |
+|-------|------|----------|---------|------------|-------------|
+| `version` | string | Yes | `v1.13.0` | Pattern: `^v\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$` | Talos version for control plane components (controller-manager, scheduler, kube-apiserver, etcd). e.g. `v1.13.0` |
+| `mode` | string | Yes | - | Enum: `container`, `metal`, `cloud` | Deployment mode. **Immutable** after creation. |
+| `replicas` | int32 | No | - | Must be >= 1 when mode is `container` | Number of control-plane machines. Only applies when mode is `container`. |
+| `metalSpec` | [MetalSpec](#metalspec) | No | - | Required when mode is `metal` | Metal-specific configuration. |
+| `endpoint` | string | No | - | Pattern: `^https?://[a-zA-Z0-9.-]+(:\d+)?$` | Kubernetes API Server endpoint URL. |
+| `kubeVersion` | string | Yes | `v1.35.0` | Pattern: `^v\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$` | Kubernetes version for the control plane. |
+| `clusterDomain` | string | No | `cluster.local` | Pattern: `^([a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?\.)+[a-z]{2,}$` | Cluster DNS domain. **Immutable** after creation. |
+| `storageClassName` | string | No | - | Pattern: `^[a-zA-Z0-9][-a-zA-Z0-9_.]*[a-zA-Z0-9]$` | StorageClass name for persistent volumes (used by etcd data, etc.). |
+| `podCIDR` | []string | No | - | Max 4 items. Each must match `^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$` | CIDR ranges for pod IPs. |
+| `serviceCIDR` | []string | No | - | Max 4 items. Each must match `^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$` | CIDR ranges for service VIPs. |
+| `configRef` | [ConfigMapKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#configmapkeyselector-v1-core) | No | - | - | Reference to a ConfigMap key containing the Talos controlplane configuration. |
+| `cni` | [CNIConfig](#cniconfig) | No | - | - | CNI plugin configuration. |
+| `deletionPolicy` | string | No | `reset` | Enum: `reset`, `preserve` | What to do to machines when this resource is deleted. `reset` wipes the Talos installation; `preserve` leaves machines as-is. |
+| `rolloutStrategy` | [RolloutStrategy](#rolloutstrategy) | No | `{type: "RollingUpdate", rollingUpdate: {maxUnavailable: 1}}` | - | Controls how Talos version upgrades roll out. Only applies when mode is `metal`. |
+
+### Cross-Field Validations
+
+| Rule | Message |
+|------|---------|
+| `clusterDomain` is immutable | ClusterDomain is immutable |
+| `mode` is immutable | Mode is immutable |
+| `mode == 'metal'` requires `metalSpec.machines` | Machines is required when mode is 'metal' |
+| `mode == 'container'` requires `replicas >= 1` | replicas must be at least 1 when mode is 'container' |
+
+---
+
+## Nested Types
+
+### MetalSpec
+
+Configuration for bare-metal / VM deployments.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `machines` | [][Machine](#machine) | Yes (when mode=metal) | - | List of machine specifications. Atomic list type (replaced as a whole). |
+| `machineSpec` | *[MachineSpec](./talosmachine.md#machinespec) | No | - | Shared machine spec applied to all machines in this set. Individual machines can override via their own fields. |
+
+### Machine
+
+Defines a single Talos machine. Either `address` or `machineRef` must be set, but not both.
+
+| Field | Type | Required | Default | Validation | Description |
+|-------|------|----------|---------|------------|-------------|
+| `address` | *string | No | - | Pattern: `^(\d{1,3}\.){3}\d{1,3}$` | IP address of the machine. Mutually exclusive with `machineRef`. |
+| `version` | string | No | - | Pattern: `^v\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$` | Per-machine Talos version override. |
+| `image` | *string | No | - | - | Talos installer image override for this machine. |
+| `pxeClientSpec` | *[PxeClientSpec](#pxeclientspec) | No | - | - | PXE boot configuration for this machine. |
+| `machineRef` | [ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectreference-v1-core) | No | - | - | Reference to a Kubernetes object whose status contains the machine IP. Mutually exclusive with `address`. |
+| `configPatches` | []RawExtension | No | - | - | Machine-specific strategic merge config patches. Applied after `machineSpec.configPatches`. |
+| `additionalConfig` | []RawExtension | No | - | - | Machine-specific additional Talos config documents. Appended after `machineSpec.additionalConfig`. |
+
+#### Cross-Field Validation
+
+| Rule | Message |
+|------|---------|
+| `has(address) != has(machineRef)` | address and machineRef are mutually exclusive |
+
+### PxeClientSpec
+
+PXE boot configuration for a machine.
+
+| Field | Type | Required | Default | Validation | Description |
+|-------|------|----------|---------|------------|-------------|
+| `macAddress` | *string | Yes | - | - | MAC address of the NIC used by the PXE firmware. e.g. `00:11:22:33:44:55` |
+| `cpuArchitecture` | *string | Yes | - | Enum: `amd64`, `arm64` | CPU architecture of the machine. |
+| `kernelCmdlineArgs` | *string | No | - | - | Additional kernel command line arguments injected during PXE boot. These are **not** preserved after installation. |
+
+### META
+
+Network metadata written to the Talos META partition.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `hostname` | string | No | - | Hostname for the machine. |
+| `interface` | string | No | - | Network interface name. e.g. `eth0` |
+| `subnet` | int | No | - | Subnet prefix length. e.g. `24` |
+| `gateway` | string | No | - | Default gateway IP address. |
+| `dnsServers` | []string | No | - | List of DNS server IP addresses. |
+
+### CNIConfig
+
+CNI plugin configuration.
+
+| Field | Type | Required | Default | Validation | Description |
+|-------|------|----------|---------|------------|-------------|
+| `name` | string | No | - | Enum: `flannel`, `custom`, `none` | CNI plugin to use. |
+| `urls` | []string | No | - | - | URLs of manifest YAMLs to apply. Required when name is `custom`; must be empty for `flannel` and `none`. |
+| `flannel` | *[FlannelCNIConfig](#flannelcniconfig) | No | - | - | Flannel-specific options. |
+
+### FlannelCNIConfig
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `extraArgs` | []string | No | - | Extra arguments passed to `flanneld`. |
+| `kubeNetworkPoliciesEnabled` | *bool | No | - | Deploy `kube-network-policies` to enable Kubernetes NetworkPolicy support. |
+
+### RolloutStrategy
+
+Controls how Talos version upgrades are rolled out across machines.
+
+| Field | Type | Required | Default | Validation | Description |
+|-------|------|----------|---------|------------|-------------|
+| `type` | [RolloutStrategyType](#rolloutstrategytype) | No | `RollingUpdate` | Enum: `RollingUpdate` | Strategy type. Currently only `RollingUpdate` is supported. |
+| `rollingUpdate` | *[RollingUpdateRolloutStrategy](#rollingupdaterolloutstrategy) | No | - | - | Rolling update parameters. Only used when `type` is `RollingUpdate`. |
+
+### RollingUpdateRolloutStrategy
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `maxUnavailable` | *[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#intorstring-intstr-util) | No | `1` | Maximum number of machines upgrading simultaneously. Can be an absolute number (e.g. `1`) or a percentage of total machines (e.g. `"25%"`). |
+
+### RolloutStrategyType
+
+| Value | Description |
+|-------|-------------|
+| `RollingUpdate` | Upgrades machines one cohort at a time, gated by `maxUnavailable` and per-machine health checks. |
+
+---
+
+## Status Fields
+
+### `status` (TalosControlPlaneStatus)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `state` | string | Current reconciliation state (e.g. `Ready`, `Provisioning`, `Failed`). |
+| `conditions` | [][Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta) | List of conditions. Map-list keyed by `type`. |
+| `config` | string | Reference to the Talos configuration resource. |
+| `secretBundle` | string | Reference to the secrets bundle. |
+| `bundleConfig` | string | Reference to the bundle configuration. |
+| `imported` | *bool | Indicates whether the control plane has been imported (only relevant for import reconciliation mode). |
+| `observedKubeVersion` | string | The last observed Kubernetes version on the control plane. |

--- a/docs/crds/talosetcdbackup.md
+++ b/docs/crds/talosetcdbackup.md
@@ -1,56 +1,26 @@
 # TalosEtcdBackup
 
-The `TalosEtcdBackup` custom resource enables automated etcd backups for Talos control planes, streaming snapshots directly to S3-compatible storage without local disk usage.
+| Field | Value |
+|-------|-------|
+| **API Group** | `talos.alperen.cloud` |
+| **API Version** | `v1alpha1` |
+| **Kind** | `TalosEtcdBackup` |
+| **Short Names** | `teb` |
+| **Scope** | Namespaced |
+| **Subresources** | `status` |
 
-## Overview
+`TalosEtcdBackup` creates a one-time etcd backup from a Talos control plane, streaming the snapshot directly to S3-compatible storage with zero local disk I/O.
 
-TalosEtcdBackup provides a declarative way to backup etcd data from Talos control planes. The operator:
+## Print Columns
 
-1. Connects to the Talos API to stream an etcd snapshot
-2. Uploads the snapshot directly to S3 (or S3-compatible storage)
-3. Uses zero local disk I/O for minimal footprint
-4. Updates status conditions to track backup progress
+| Name | JSON Path |
+|------|-----------|
+| Filename | `.status.filename` |
+| Age | `.metadata.creationTimestamp` |
 
-## Features
-
-- **Zero Local I/O**: Snapshots stream directly from Talos API to S3
-- **Memory Efficient**: Uses streaming to minimize memory footprint
-- **S3 Compatible**: Works with AWS S3, MinIO, Ceph, and other S3-compatible storage
-- **Secure**: Credentials stored in Kubernetes secrets
-- **Status Tracking**: Updates conditions for easy monitoring
-
-## Specification
-
-### Required Fields
-
-- `spec.talosControlPlaneRef`: Reference to the TalosControlPlane to backup
-- `spec.backupStorage.s3.bucket`: S3 bucket name
-- `spec.backupStorage.s3.region`: AWS region
-- `spec.backupStorage.s3.accessKeyID`: Secret reference for access key ID
-- `spec.backupStorage.s3.secretAccessKey`: Secret reference for secret access key
-
-### Optional Fields
-
-- `spec.backupStorage.s3.endpoint`: Custom S3 endpoint (for S3-compatible storage)
-- `spec.backupStorage.s3.insecureSkipTLSVerify`: Skip TLS verification (default: false)
+---
 
 ## Example
-
-### 1. Create S3 Credentials Secret
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: my-s3-credentials
-  namespace: default
-type: Opaque
-stringData:
-  accessKeyID: "YOUR_ACCESS_KEY_ID"
-  secretAccessKey: "YOUR_SECRET_ACCESS_KEY"
-```
-
-### 2. Create TalosEtcdBackup Resource
 
 ```yaml
 apiVersion: talos.alperen.cloud/v1alpha1
@@ -72,21 +42,7 @@ spec:
         key: secretAccessKey
 ```
 
-### 3. Check Backup Status
-
-```bash
-kubectl get talosetcdbackup my-backup -o yaml
-```
-
-Look for the `status.conditions` field to check backup progress:
-
-- `Progressing`: Backup is in progress
-- `Ready`: Backup completed successfully
-- `Failed`: Backup encountered an error
-
-## Using S3-Compatible Storage
-
-For MinIO, Ceph, or other S3-compatible storage, add the `endpoint` field:
+### With Custom S3 Endpoint (MinIO, Ceph, etc.)
 
 ```yaml
 spec:
@@ -95,7 +51,7 @@ spec:
       bucket: my-backups
       region: us-east-1
       endpoint: https://minio.example.com
-      insecureSkipTLSVerify: false  # Set to true for self-signed certs
+      insecureSkipTLSVerify: false
       accessKeyID:
         name: my-s3-credentials
         key: accessKeyID
@@ -104,76 +60,51 @@ spec:
         key: secretAccessKey
 ```
 
-## Backup Location
+---
 
-Backups are stored in S3 with the following key pattern:
+## Spec Fields
 
-```
-talos-operator-etcd-backups/<controlplane-name>/etcd-snapshot-<timestamp>.db
-```
+### `spec` (TalosEtcdBackupSpec)
 
-Example:
-```
-talos-operator-etcd-backups/my-controlplane/etcd-snapshot-2025-10-04T11-30-00Z.db
-```
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `talosControlPlaneRef` | [LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#localobjectreference-v1-core) | Yes | - | Reference to the `TalosControlPlane` to back up (by name). |
+| `backupStorage` | [BackupStorage](#backupstorage) | Yes | - | Storage configuration for the backup. |
 
-## Status Conditions
+### BackupStorage
 
-The operator updates status conditions throughout the backup lifecycle:
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `s3` | *[S3Storage](#s3storage) | No | - | S3-compatible storage configuration. |
 
-| Condition | Status | Reason | Description |
-|-----------|--------|--------|-------------|
-| Progressing | True | BackupInProgress | Backup is currently running |
-| Progressing | False | BackupCompleted | Backup finished |
-| Ready | True | BackupSucceeded | Backup completed successfully |
-| Failed | True | BackupFailed | Backup encountered an error |
+### S3Storage
 
-## Best Practices
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `bucket` | string | Yes | - | S3 bucket name. |
+| `region` | string | Yes | - | AWS region where the bucket is located. |
+| `endpoint` | string | No | - | Custom S3 endpoint URL for S3-compatible services (MinIO, Ceph, etc.). |
+| `accessKeyID` | [SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#secretkeyselector-v1-core) | Yes | - | Reference to a Secret key containing the S3 access key ID. |
+| `secretAccessKey` | [SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#secretkeyselector-v1-core) | Yes | - | Reference to a Secret key containing the S3 secret access key. |
+| `insecureSkipTLSVerify` | bool | No | `false` | Skip TLS certificate verification for the S3 endpoint. |
 
-1. **Credentials Management**: Always use Kubernetes secrets for S3 credentials
-2. **Bucket Lifecycle**: Configure S3 lifecycle policies for automatic cleanup
-3. **Monitoring**: Watch status conditions for backup health
-4. **Testing**: Test restores regularly to ensure backups are valid
-5. **Network**: Ensure operator has network access to S3 endpoint
+---
 
-## Troubleshooting
+## Status Fields
 
-### Backup Fails with "Failed to get TalosControlPlane"
+### `status` (TalosEtcdBackupStatus)
 
-Ensure:
-- The referenced TalosControlPlane exists in the same namespace
-- The TalosControlPlane is in a ready state with valid bundle config
+| Field | Type | Description |
+|-------|------|-------------|
+| `filename` | string | Name of the etcd snapshot file in the storage backend. Pattern: `talos-operator-etcd-backups/<controlplane-name>/etcd-snapshot-<timestamp>.db` |
+| `stateFilename` | string | Name of the paired state-secret backup file in the storage backend. |
+| `conditions` | [][Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta) | List of conditions. Map-list keyed by `type`. |
 
-### Backup Fails with "Failed to get secret"
+#### Condition Types
 
-Ensure:
-- The secret exists in the same namespace as the TalosEtcdBackup
-- The secret contains the correct keys (`accessKeyID` and `secretAccessKey`)
-
-### Backup Fails with "Failed to upload snapshot to S3"
-
-Check:
-- S3 credentials have write permissions to the bucket
-- Network connectivity to S3 endpoint
-- Bucket exists and is in the correct region
-- For custom endpoints, verify the endpoint URL is correct
-
-### Backup Hangs in Progressing State
-
-- Check operator logs for detailed error messages
-- Verify Talos API is accessible from the operator
-- Ensure sufficient network bandwidth for snapshot transfer
-
-## Performance Considerations
-
-The backup process streams data directly from Talos to S3:
-
-- **Memory Usage**: Minimal, as data is streamed (not buffered)
-- **Disk Usage**: Zero, no local storage is used
-- **Network**: Bandwidth dependent on snapshot size
-- **Duration**: Depends on snapshot size and network speed
-
-For large etcd databases, ensure:
-- Adequate network bandwidth between operator and S3
-- Sufficient Talos API timeout settings
-- Monitoring of backup completion times
+| Type | Status | Reason | Description |
+|------|--------|--------|-------------|
+| `Progressing` | `True` | `BackupInProgress` | Backup is currently running. |
+| `Progressing` | `False` | `BackupCompleted` | Backup finished. |
+| `Ready` | `True` | `BackupSucceeded` | Backup completed successfully. |
+| `Failed` | `True` | `BackupFailed` | Backup encountered an error. |

--- a/docs/crds/talosetcdbackupschedule.md
+++ b/docs/crds/talosetcdbackupschedule.md
@@ -1,71 +1,38 @@
 # TalosEtcdBackupSchedule
 
-The `TalosEtcdBackupSchedule` custom resource enables automated, periodic etcd backups for Talos control planes on a schedule. It creates `TalosEtcdBackup` resources based on a cron schedule and manages retention of old backups.
+| Field | Value |
+|-------|-------|
+| **API Group** | `talos.alperen.cloud` |
+| **API Version** | `v1alpha1` |
+| **Kind** | `TalosEtcdBackupSchedule` |
+| **Short Names** | `tebs` |
+| **Scope** | Namespaced |
+| **Subresources** | `status` |
 
-## Overview
+`TalosEtcdBackupSchedule` creates `TalosEtcdBackup` resources on a cron schedule and manages retention of old backups.
 
-`TalosEtcdBackupSchedule` automates the process of creating regular etcd backups by:
-- Creating backups on a cron schedule
-- Managing backup retention (automatically deleting old backups)
-- Providing status information about the schedule
-- Supporting pause/resume functionality
+## Print Columns
 
-## Features
+| Name | JSON Path |
+|------|-----------|
+| Schedule | `.spec.schedule` |
+| Last Backup | `.status.lastSuccessfulBackupTime` |
+| Next Backup | `.status.nextScheduleTime` |
+| Paused | `.spec.paused` |
 
-- **Cron-based Scheduling**: Define backup schedules using standard cron expressions
-- **Automatic Backup Creation**: Creates `TalosEtcdBackup` resources automatically based on schedule
-- **Retention Management**: Automatically removes old backups based on retention policy
-- **Pause/Resume**: Ability to pause and resume backup schedules
-- **Status Tracking**: View last backup time, next scheduled backup, and active backups
-
-## Specification
-
-### Required Fields
-
-- `spec.schedule`: Cron expression defining when to run backups (e.g., "0 2 * * *" for daily at 2 AM)
-- `spec.backupTemplate.spec.talosControlPlaneRef`: Reference to the TalosControlPlane to backup
-- `spec.backupTemplate.spec.backupStorage.s3.bucket`: S3 bucket name
-- `spec.backupTemplate.spec.backupStorage.s3.region`: AWS region
-- `spec.backupTemplate.spec.backupStorage.s3.accessKeyID`: Secret reference for access key ID
-- `spec.backupTemplate.spec.backupStorage.s3.secretAccessKey`: Secret reference for secret access key
-
-### Optional Fields
-
-- `spec.retention`: Number of successful backups to keep (default: 5)
-- `spec.paused`: Set to true to pause the backup schedule (default: false)
-- `spec.backupTemplate.spec.backupStorage.s3.endpoint`: Custom S3 endpoint
-- `spec.backupTemplate.spec.backupStorage.s3.insecureSkipTLSVerify`: Skip TLS verification (default: false)
+---
 
 ## Example
-
-### 1. Create S3 Credentials Secret
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: my-s3-credentials
-  namespace: default
-type: Opaque
-stringData:
-  accessKeyID: "YOUR_ACCESS_KEY_ID"
-  secretAccessKey: "YOUR_SECRET_ACCESS_KEY"
-```
-
-### 2. Create TalosEtcdBackupSchedule Resource
 
 ```yaml
 apiVersion: talos.alperen.cloud/v1alpha1
 kind: TalosEtcdBackupSchedule
 metadata:
-  name: daily-backup-schedule
+  name: daily-backup
 spec:
-  # Daily backups at 2 AM
   schedule: "0 2 * * *"
-  
-  # Keep 7 daily backups
   retention: 7
-  
+  paused: false
   backupTemplate:
     spec:
       talosControlPlaneRef:
@@ -82,139 +49,52 @@ spec:
             key: secretAccessKey
 ```
 
-### 3. Check Schedule Status
+---
 
-```bash
-kubectl get talosetcdbackupschedule daily-backup-schedule -o yaml
-```
+## Spec Fields
 
-Look for the `status` fields:
-- `lastScheduleTime`: When the last backup was created
-- `lastSuccessfulBackupTime`: When the last backup completed successfully
-- `nextScheduleTime`: When the next backup will be created
-- `activeBackups`: List of currently running backups
+### `spec` (TalosEtcdBackupScheduleSpec)
 
-## Cron Schedule Examples
+| Field | Type | Required | Default | Validation | Description |
+|-------|------|----------|---------|------------|-------------|
+| `schedule` | string | Yes | - | MinLength: 1 | Cron expression defining when to trigger backups. e.g. `"0 2 * * *"` for daily at 2 AM. |
+| `backupTemplate` | [TalosEtcdBackupTemplateSpec](#talosetcdbackuptemplatespec) | Yes | - | - | Template for the `TalosEtcdBackup` resources created by this schedule. |
+| `retention` | *int32 | No | `5` | Minimum: 1 | Number of successful backups to keep. Older backups are automatically deleted. |
+| `paused` | bool | No | `false` | - | Pause the schedule. No new backups will be created while `true`. |
 
-| Schedule | Description |
-|----------|-------------|
+### TalosEtcdBackupTemplateSpec
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `spec` | [TalosEtcdBackupSpec](./talosetcdbackup.md#spec-fields) | Yes | - | The full `TalosEtcdBackupSpec` used as the template for each created backup. |
+
+### Cron Schedule Examples
+
+| Expression | Description |
+|------------|-------------|
 | `0 2 * * *` | Daily at 2:00 AM |
 | `0 */6 * * *` | Every 6 hours |
 | `0 0 * * 0` | Weekly on Sunday at midnight |
 | `0 0 1 * *` | Monthly on the 1st at midnight |
 | `*/15 * * * *` | Every 15 minutes |
 
-For more cron syntax help, see [crontab.guru](https://crontab.guru/).
+---
 
-## Pausing and Resuming Schedules
+## Status Fields
 
-To pause a backup schedule:
+### `status` (TalosEtcdBackupScheduleStatus)
 
-```bash
-kubectl patch talosetcdbackupschedule daily-backup-schedule --type merge -p '{"spec":{"paused":true}}'
-```
+| Field | Type | Description |
+|-------|------|-------------|
+| `lastScheduleTime` | *[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#time-v1-meta) | Timestamp of the last time a backup was scheduled. |
+| `lastSuccessfulBackupTime` | *[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#time-v1-meta) | Timestamp of the last successful backup completion. |
+| `nextScheduleTime` | *[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#time-v1-meta) | Timestamp of the next scheduled backup. |
+| `activeBackups` | []string | Names of currently active (in-progress) backup resources. |
+| `conditions` | [][Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta) | List of conditions. Map-list keyed by `type`. |
 
-To resume:
+#### Condition Types
 
-```bash
-kubectl patch talosetcdbackupschedule daily-backup-schedule --type merge -p '{"spec":{"paused":false}}'
-```
-
-## Retention Policy
-
-The `retention` field specifies how many successful backups to keep. When this number is exceeded, the oldest backups are automatically deleted. This applies only to successful backups; failed backups are not counted against the retention limit.
-
-For example, with `retention: 5`:
-- The 5 most recent successful backups are kept
-- Older successful backups are automatically deleted
-- Failed or in-progress backups are not deleted automatically
-
-## Backup Naming
-
-Backups created by the schedule are automatically named using the pattern:
-```
-<schedule-name>-<timestamp>
-```
-
-For example: `daily-backup-schedule-1704153600`
-
-## Status Conditions
-
-The schedule maintains status conditions:
-
-- `Ready`: Schedule is active and functioning normally
-- `Failed`: Schedule encountered an error (e.g., invalid cron expression)
-
-## Best Practices
-
-1. **Schedule During Low Traffic**: Schedule backups during periods of lower cluster activity to minimize impact
-2. **Set Appropriate Retention**: Balance storage costs with recovery point objectives (RPO)
-3. **Monitor Backup Status**: Regularly check that backups are completing successfully
-4. **Test Restores**: Periodically test restoring from backups to ensure they are valid
-5. **Use Separate Schedules**: Consider separate schedules for different retention policies (e.g., hourly, daily, weekly)
-
-## Troubleshooting
-
-### Schedule Not Creating Backups
-
-1. Check if the schedule is paused:
-   ```bash
-   kubectl get talosetcdbackupschedule <name> -o jsonpath='{.spec.paused}'
-   ```
-
-2. Verify the cron expression is valid:
-   ```bash
-   kubectl get talosetcdbackupschedule <name> -o jsonpath='{.status.conditions}'
-   ```
-
-3. Check controller logs:
-   ```bash
-   kubectl logs -n talos-operator-system deployment/talos-operator-controller-manager
-   ```
-
-### Backups Not Being Deleted
-
-Check the retention policy:
-```bash
-kubectl get talosetcdbackupschedule <name> -o jsonpath='{.spec.retention}'
-```
-
-Only successful backups count toward retention. Failed or in-progress backups are not automatically cleaned up.
-
-### Invalid Cron Expression
-
-If you see a `Failed` condition with reason `InvalidSchedule`, verify your cron expression:
-- Use standard cron format: `minute hour day month weekday`
-- Test your expression at [crontab.guru](https://crontab.guru/)
-
-## Relationship with TalosEtcdBackup
-
-`TalosEtcdBackupSchedule` creates `TalosEtcdBackup` resources automatically. You can view all backups created by a schedule:
-
-```bash
-kubectl get talosetcdbackup -l talos.alperen.cloud/backup-schedule=<schedule-name>
-```
-
-Each backup is owned by the schedule, so deleting the schedule will also delete all its backups.
-
-## Using S3-Compatible Storage
-
-The schedule supports any S3-compatible storage service (MinIO, Ceph, etc.):
-
-```yaml
-spec:
-  backupTemplate:
-    spec:
-      backupStorage:
-        s3:
-          bucket: etcd-backups
-          region: us-east-1
-          endpoint: https://minio.example.com
-          insecureSkipTLSVerify: false
-          accessKeyID:
-            name: minio-credentials
-            key: accessKeyID
-          secretAccessKey:
-            name: minio-credentials
-            key: secretAccessKey
-```
+| Type | Status | Reason | Description |
+|------|--------|--------|-------------|
+| `Ready` | `True` | - | Schedule is active and functioning normally. |
+| `Failed` | `True` | `InvalidSchedule` | Invalid cron expression or other configuration error. |

--- a/docs/crds/talosmachine.md
+++ b/docs/crds/talosmachine.md
@@ -1,6 +1,101 @@
 # TalosMachine
 
-`TalosMachine` is a Kubernetes custom resource definition (CRD) that represents a machine running Talos, a modern operating system designed for Kubernetes. This CRD is used to manage the lifecycle of Talos machines within a Kubernetes cluster. It's subsidiary to the `TalosControlPlane` and `TalosWoorker` resources, when they are defined in `metal` mode, and is used to manage the individual machines that make up the Talos cluster. No matter the mode that you run you shouldn't define `TalosMachine` resources directly, but rather use the `TalosControlPlane` and `TalosWorker` resources to manage the machines. TalosMachines are created and managed by the Talos operator, to be able to track each machine individually and apply the desired state defined in the `TalosControlPlane` or `TalosWorker` resources. You can use `TalosMachine` to monitor the status of each machine, including its health, configuration, and any issues that may arise. The Talos operator will ensure that the machines are running the correct version of Talos and are configured according to the specifications defined in the `TalosControlPlane` or `TalosWorker` resources.
+| Field | Value |
+|-------|-------|
+| **API Group** | `talos.alperen.cloud` |
+| **API Version** | `v1alpha1` |
+| **Kind** | `TalosMachine` |
+| **Short Names** | `tm` |
+| **Scope** | Namespaced |
+| **Subresources** | `status` |
+
+`TalosMachine` represents a single Talos machine. It is created and managed by the operator when `TalosControlPlane` or `TalosWorker` are in `metal` mode. It tracks the per-machine lifecycle including configuration, version, and health.
 
 !!!warning
-    Users shouldn't define `TalosMachine` resources directly, but rather use the `TalosControlPlane` and `TalosWorker` resources to manage the machines. The Talos operator will automatically create and manage the `TalosMachine` resources based on the specifications defined in the `TalosControlPlane` or `TalosWorker` resources.
+    Users should not create `TalosMachine` resources directly. They are automatically created and managed by the operator based on `TalosControlPlane` and `TalosWorker` specifications.
+
+## Print Columns
+
+| Name | JSON Path |
+|------|-----------|
+| State | `.status.state` |
+| Version | `.spec.version` |
+| Endpoint | `.spec.endpoint` |
+| Age | `.metadata.creationTimestamp` |
+
+---
+
+## Example
+
+```yaml
+apiVersion: talos.alperen.cloud/v1alpha1
+kind: TalosMachine
+metadata:
+  name: my-controlplane-machine-0
+spec:
+  endpoint: 192.168.1.101
+  version: v1.13.0
+  machineSpec:
+    installDisk: /dev/sda
+    wipe: false
+    airGap: false
+    imageCache: false
+  controlPlaneRef:
+    name: my-controlplane
+  deletionPolicy: reset
+  pxeClientSpec:
+    macAddress: "00:11:22:33:44:55"
+    cpuArchitecture: amd64
+```
+
+---
+
+## Spec Fields
+
+### `spec` (TalosMachineSpec)
+
+| Field | Type | Required | Default | Validation | Description |
+|-------|------|----------|---------|------------|-------------|
+| `endpoint` | string | Yes | - | - | Talos API endpoint (IP or hostname) for this machine. |
+| `version` | string | Yes | - | - | Desired Talos version to run on this machine. |
+| `machineSpec` | *[MachineSpec](#machinespec) | No | - | - | Machine-level configuration (disk, network, config patches, etc.). |
+| `controlPlaneRef` | [ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectreference-v1-core) | No | - | - | Reference to the `TalosControlPlane` this machine belongs to. |
+| `workerRef` | [ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectreference-v1-core) | No | - | - | Reference to the `TalosWorker` this machine belongs to. |
+| `configRef` | [ConfigMapKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#configmapkeyselector-v1-core) | No | - | - | Reference to a ConfigMap key containing the Talos machine configuration. |
+| `deletionPolicy` | string | No | `reset` | Enum: `reset`, `preserve` | What to do when this resource is deleted. `reset` wipes Talos; `preserve` leaves the machine as-is. |
+| `pxeClientSpec` | [PxeClientSpec](./taloscontrolplane.md#pxeclientspec) | No | - | - | PXE boot configuration for this machine. |
+
+---
+
+## Nested Types
+
+### MachineSpec
+
+Shared machine configuration used by both `TalosControlPlane` (via `MetalSpec.machineSpec`) and `TalosMachine`.
+
+| Field | Type | Required | Default | Validation | Description |
+|-------|------|----------|---------|------------|-------------|
+| `installDisk` | *string | No | - | Pattern: `^/dev/(sd[a-z][0-9]*\|vd[a-z][0-9]*\|nvme[0-9]+n[0-9]+(p[0-9]+)?)$` | Disk device for Talos installation. e.g. `/dev/sda`, `/dev/nvme0n1` |
+| `wipe` | bool | No | `false` | - | Wipe the installation disk before installing Talos. |
+| `image` | *string | No | - | - | Custom Talos installer image. |
+| `meta` | [META](./taloscontrolplane.md#meta) | No | - | - | Network metadata written to the Talos META partition. |
+| `airGap` | bool | No | `false` | - | Indicates the machine is in an air-gapped environment with no internet access. |
+| `imageCache` | bool | No | `false` | - | Enable local image caching on the machine. |
+| `allowSchedulingOnControlPlanes` | bool | No | `false` | - | Allow scheduling regular workloads on control plane nodes (removes the NoSchedule taint). |
+| `registries` | [RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#rawextension-runtime-pkg) | No | - | - | Custom container registry configuration (Talos registries YAML document). |
+| `additionalConfig` | [][RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#rawextension-runtime-pkg) | No | - | - | Additional Talos configuration documents to append. Each entry is a separate YAML document joined with `---`. Applied in order: global first, then machine-specific. |
+| `configPatches` | [][RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#rawextension-runtime-pkg) | No | - | - | Strategic merge patches applied to the generated Talos machine config. Unlike `additionalConfig`, each patch is merged into the main config to override or extend fields (e.g. `machine.network`). |
+
+---
+
+## Status Fields
+
+### `status` (TalosMachineStatus)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `observedVersion` | string | The version of Talos currently running on this machine. |
+| `config` | string | Base64-encoded Talos machine configuration. |
+| `imported` | *bool | Whether this machine has been imported (only relevant for import reconciliation mode). |
+| `state` | string | Current state (e.g. `Ready`, `Provisioning`, `Failed`). |
+| `conditions` | [][Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta) | List of conditions. Map-list keyed by `type`. |

--- a/docs/crds/talosworker.md
+++ b/docs/crds/talosworker.md
@@ -1,6 +1,124 @@
 # TalosWorker
 
-`TalosWorker` is a Kubernetes custom resource definition (CRD) that represents worker nodes in a Talos cluster. It is used to manage the lifecycle of worker nodes. The `TalosWorker` resource allows users to define the desired state of worker nodes, including their configuration, networking settings, and other parameters. It is typically used in conjunction with the `TalosControlPlane` resource to manage the entire Talos cluster. Unlike the `TalosControlPlane`, which is responsible for the control plane nodes, you can't define `TalosWorker` resource indiviually, because it requires a reference to a valid `TalosControlPlane` object. I don't find any use case where you would want to define `TalosWorker` resource without a `TalosControlPlane` object, so it's not allowed.
+| Field | Value |
+|-------|-------|
+| **API Group** | `talos.alperen.cloud` |
+| **API Version** | `v1alpha1` |
+| **Kind** | `TalosWorker` |
+| **Short Names** | `tw` |
+| **Scope** | Namespaced |
+| **Subresources** | `status` |
 
-!!!tip
-    For more examples please refer to [examples](https://github.com/alperencelik/talos-operator/tree/main/examples) directory in the repository.
+`TalosWorker` defines the worker nodes of a Talos Linux cluster. Unlike `TalosControlPlane`, it cannot be used standalone — it must reference a `TalosControlPlane` via `controlPlaneRef` so it can join the correct cluster.
+
+## Print Columns
+
+| Name | JSON Path |
+|------|-----------|
+| State | `.status.state` |
+| Version | `.spec.version` |
+| Mode | `.spec.mode` |
+| Age | `.metadata.creationTimestamp` |
+
+---
+
+## Modes
+
+| Mode | Description |
+|------|-------------|
+| `container` | Runs Talos workers as containers within Kubernetes pods. Requires `replicas`. |
+| `metal` | Runs Talos on bare metal or virtual machines. Requires `metalSpec`. |
+| `cloud` | Reserved for future cloud provider integration. |
+
+---
+
+## Example
+
+### Container Mode
+
+```yaml
+apiVersion: talos.alperen.cloud/v1alpha1
+kind: TalosWorker
+metadata:
+  name: my-worker
+spec:
+  version: v1.13.0
+  mode: container
+  replicas: 3
+  kubeVersion: v1.35.0
+  controlPlaneRef:
+    name: my-controlplane
+  storageClassName: standard
+  deletionPolicy: reset
+```
+
+### Metal Mode
+
+```yaml
+apiVersion: talos.alperen.cloud/v1alpha1
+kind: TalosWorker
+metadata:
+  name: my-worker
+spec:
+  version: v1.13.0
+  mode: metal
+  kubeVersion: v1.35.0
+  controlPlaneRef:
+    name: my-controlplane
+  metalSpec:
+    machines:
+      - address: "192.168.1.201"
+        pxeClientSpec:
+          macAddress: "00:11:22:33:44:77"
+          cpuArchitecture: amd64
+      - address: "192.168.1.202"
+        pxeClientSpec:
+          macAddress: "00:11:22:33:44:88"
+          cpuArchitecture: amd64
+    machineSpec:
+      installDisk: /dev/sda
+  rolloutStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+```
+
+---
+
+## Spec Fields
+
+### `spec` (TalosWorkerSpec)
+
+| Field | Type | Required | Default | Validation | Description |
+|-------|------|----------|---------|------------|-------------|
+| `version` | string | Yes | `v1.13.0` | Pattern: `^v\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$` | Talos version for worker nodes. e.g. `v1.13.0` |
+| `mode` | string | Yes | - | Enum: `container`, `metal`, `cloud` | Deployment mode. **Immutable** after creation. |
+| `replicas` | int32 | No | `1` | Must be >= 1 when mode is `container` | Number of worker machines. Only applies when mode is `container`. |
+| `metalSpec` | [MetalSpec](./taloscontrolplane.md#metalspec) | Yes (when mode=metal) | - | - | Metal-specific configuration. Uses the same `MetalSpec` type as `TalosControlPlane`. |
+| `kubeVersion` | string | Yes | `v1.35.0` | Pattern: `^v\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$` | Kubernetes version for worker nodes. |
+| `storageClassName` | *string | No | - | Pattern: `^[a-zA-Z0-9][-a-zA-Z0-9_.]*[a-zA-Z0-9]$` | StorageClass for persistent volumes. **Immutable** after creation. |
+| `controlPlaneRef` | [LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#localobjectreference-v1-core) | Yes | - | - | Reference to the `TalosControlPlane` this worker belongs to (by name). |
+| `configRef` | [ConfigMapKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#configmapkeyselector-v1-core) | No | - | - | Reference to a ConfigMap key containing the Talos worker configuration. |
+| `deletionPolicy` | string | No | `reset` | Enum: `reset`, `preserve` | What to do to machines when this resource is deleted. `reset` wipes Talos; `preserve` leaves machines as-is. |
+| `rolloutStrategy` | [RolloutStrategy](./taloscontrolplane.md#rolloutstrategy) | No | `{type: "RollingUpdate", rollingUpdate: {maxUnavailable: 1}}` | - | Controls how Talos version upgrades roll out. Only applies when mode is `metal`. |
+
+### Cross-Field Validations
+
+| Rule | Message |
+|------|---------|
+| `mode` is immutable | Mode is immutable |
+| `mode == 'metal'` requires `metalSpec` | MetalSpec is required when mode 'metal' |
+| `mode == 'container'` requires `replicas >= 1` | replicas must be at least 1 when mode is 'container' |
+
+---
+
+## Status Fields
+
+### `status` (TalosWorkerStatus)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `conditions` | [][Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta) | List of conditions. Map-list keyed by `type`. |
+| `config` | string | Serialized Talos worker configuration. |
+| `imported` | *bool | Whether this worker has been imported (only relevant for import reconciliation mode). |
+| `state` | string | Current state (e.g. `Ready`, `Provisioning`, `Failed`). |

--- a/internal/controller/machine_common.go
+++ b/internal/controller/machine_common.go
@@ -112,6 +112,18 @@ func getMachineIPAddress(ctx context.Context, c client.Client, machine *talosv1a
 	return nil, nil
 }
 
+func rawExtensionToYAML(raw runtime.RawExtension) ([]byte, error) {
+	var obj any
+	if err := yaml.Unmarshal(raw.Raw, &obj); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal additionalConfig: %w", err)
+	}
+	out, err := yaml.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal additionalConfig to YAML: %w", err)
+	}
+	return out, nil
+}
+
 // rawExtensionsToPatches converts a slice of RawExtension config patches to YAML strings
 // suitable for passing to talos.GenerateControlPlaneConfig or talos.GenerateWorkerConfig.
 func rawExtensionsToPatches(patches []runtime.RawExtension) ([]string, error) {

--- a/internal/controller/talosmachine_controller.go
+++ b/internal/controller/talosmachine_controller.go
@@ -254,7 +254,11 @@ func (r *TalosMachineReconciler) handleControlPlaneMachine(ctx context.Context, 
 		if tm.Spec.MachineSpec != nil {
 			for _, ac := range tm.Spec.MachineSpec.AdditionalConfig {
 				*cpConfig = append(*cpConfig, []byte("\n---\n")...)
-				*cpConfig = append(*cpConfig, ac.Raw...)
+				yamlBytes, err := rawExtensionToYAML(ac)
+				if err != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to convert additionalConfig to YAML for TalosMachine %s: %w", tm.Name, err)
+				}
+				*cpConfig = append(*cpConfig, yamlBytes...)
 			}
 		}
 	}


### PR DESCRIPTION
Better documentation for CRDs fields and an additionalConfig YAML formatting fix from [issue](https://github.com/alperencelik/talos-operator/issues/70).