### PR TITLE
fix: Generating text templates instead of html to avoid unwanted characters replacements.

### DIFF
--- a/internal/controller/cluster_common.go
+++ b/internal/controller/cluster_common.go
@@ -4,7 +4,6 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"html/template"
 	"io"
 	"net/http"
 	"os"
@@ -12,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"syscall"
+	"text/template"
 
 	talosv1alpha1 "github.com/alperencelik/talos-operator/api/v1alpha1"
 )


### PR DESCRIPTION
This PR fixes situations where data passed to the template engine when generating PXE related configuration files contains characters like "+". These characters would be replaced to sanitize the resulting file, but this is irrelevant in our case since we are not generating HTML pages (see https://github.com/golang/go/issues/42506).